### PR TITLE
Fix error when upserting custom AutoFields

### DIFF
--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -182,7 +182,8 @@ def _get_upsert_sql(
     all_fields = [
         field
         for field in model._meta.fields
-        if field.column != model._meta.pk.name or not field.auto_created
+        if field.column in unique_fields
+        or not isinstance(field, models.AutoField)
     ]
 
     all_field_names = [field.column for field in all_fields]

--- a/pgbulk/tests/models.py
+++ b/pgbulk/tests/models.py
@@ -4,6 +4,13 @@ from django.db import models
 from timezone_field import TimeZoneField
 
 
+class TestAutoFieldModel(models.Model):
+    id = models.AutoField(primary_key=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    widget = models.TextField(unique=True)
+    data = models.TextField()
+
+
 class TestModel(models.Model):
     """
     A model for testing manager utils.

--- a/pgbulk/tests/test_core.py
+++ b/pgbulk/tests/test_core.py
@@ -10,6 +10,19 @@ from pgbulk.tests import models
 
 
 @pytest.mark.django_db
+def test_auto_field_upsert():
+    """Verifies that upsert works with custom AutoFields"""
+    pgbulk.upsert(
+        models.TestAutoFieldModel,
+        [models.TestAutoFieldModel(widget='widget', data='data')],
+        ["widget"],
+        ["data"],
+    )
+
+    assert models.TestAutoFieldModel.objects.count() == 1
+
+
+@pytest.mark.django_db
 def test_sync_w_char_pk():
     """
     Tests with a model that has a char pk.


### PR DESCRIPTION
``upsert()`` previously errored when using a custom auto-incrementing field. This
has been tested and fixed.

Type: bug

This addresses #3 