### PR TITLE
Handle func-based fields and allow expressions in upserts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,8 @@ provides several optimized bulk operations for Postgres:
    postgres ``UPDATE ON CONFLICT`` syntax to perform an atomic upsert
    operation. There are several options to this function that allow the
    user to avoid touching rows if they result in a duplicate update, along
-   with returning which rows were updated, created, or untouched.
+   with returning which rows were updated, created, or untouched. Users can
+   also use ``models.F`` objects on conflicts.
 3. ``sync`` - For syncing a list of models with a table. Does a bulk
    upsert and also deletes any rows in the source queryset that were not
    part of the input data.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,8 @@ provides several optimized bulk operations for Postgres:
    postgres ``UPDATE ON CONFLICT`` syntax to perform an atomic upsert
    operation. There are several options to this function that allow the
    user to avoid touching rows if they result in a duplicate update, along
-   with returning which rows were updated, created, or untouched.
+   with returning which rows were updated, created, or untouched. Users can
+   also use ``models.F`` objects on conflicts.
 3. `pgbulk.sync` - For syncing a list of models with a table. Does a bulk
    upsert and also deletes any rows in the source queryset that were not
    part of the input data.

--- a/pgbulk/__init__.py
+++ b/pgbulk/__init__.py
@@ -1,6 +1,7 @@
 from pgbulk.core import sync
 from pgbulk.core import update
+from pgbulk.core import UpdateField
 from pgbulk.core import upsert
 
 
-__all__ = ['update', 'upsert', 'sync']
+__all__ = ['update', 'upsert', 'sync', 'UpdateField']

--- a/pgbulk/tests/models.py
+++ b/pgbulk/tests/models.py
@@ -4,6 +4,12 @@ from django.db import models
 from timezone_field import TimeZoneField
 
 
+class TestFuncFieldModel(models.Model):
+    my_key = models.CharField(unique=True, max_length=32)
+    int_val = models.IntegerField()
+    other_int_val = models.IntegerField(default=1)
+
+
 class TestAutoFieldModel(models.Model):
     id = models.AutoField(primary_key=True)
     created_at = models.DateTimeField(auto_now_add=True)


### PR DESCRIPTION
``pgbulk.upsert`` allows users to provide a ``pgbulk.UpdateField`` object
to the ``update_fields`` argument, allowing a users to specify an expression
that happens if an update occurs.

This allows, for example, a user to do ``models.F('my_field') + 1`` and
increment integer fields in a ``pgbulk.upsert``.

Along with this, fields that cast to ``Func`` and other expressions are
properly handled during upsert.

Type: feature