### PR TITLE
Add `py.typed` File, Fix Minor Typing Issue

### DIFF
--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -411,7 +411,7 @@ def _upsert(
 def update(
     queryset: Union[Type[models.Model], models.QuerySet],
     model_objs: Iterable[models.Model],
-    update_fields: UpdateFieldsTypeDef = None,
+    update_fields: Union[List[str], None] = None,
 ) -> None:
     """
     Performs a bulk update.
@@ -519,7 +519,7 @@ def update(
 async def aupdate(
     queryset: Union[Type[models.Model], models.QuerySet],
     model_objs: Iterable[models.Model],
-    update_fields: UpdateFieldsTypeDef = None,
+    update_fields: Union[List[str], None] = None,
 ) -> None:
     """
     Perform an asynchronous bulk update.


### PR DESCRIPTION
We need a `py.typed` file for this library's types to be properly recognized by type-checkers. Make minor typing fix to `update`.