### PR TITLE
Add `exclude` argument to `upsert` and `update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.2.0 (2023-11-26)
+
+### Feature
+
+  - Django 5.0 compatibility [Wesley Kendall, e7848ed]
+
+    Support and test against Django 5 with psycopg2 and psycopg3.
+
+## 2.1.1 (2023-11-23)
+
+### Trivial
+
+  - Add py.typed file, fix typing issues [Maxwell Muoto, 76f6e77]
+
 ## 2.1.0 (2023-11-03)
 
 ### Bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.3 (2023-10-09)
+
+### Trivial
+
+  - Added Opus10 branding to docs [Wesley Kendall, c2f9d18]
+
 ## 2.0.2 (2023-10-08)
 
 ### Trivial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,77 +1,54 @@
 # Changelog
 
-## 2.2.0 (2023-11-26)
-
-### Feature
-
-  - Django 5.0 compatibility [Wesley Kendall, e7848ed]
-
-    Support and test against Django 5 with psycopg2 and psycopg3.
-
-## 2.1.1 (2023-11-23)
-
-### Trivial
-
-  - Add py.typed file, fix typing issues [Maxwell Muoto, 76f6e77]
-
-## 2.1.0 (2023-11-03)
-
-### Bug
-
-  - Allow updates on custom primary key fields [Wesley Kendall, 4dbfb1c]
-
-    `pgbulk.update` would fail on models with custom primary key fields when
-    no `update_fields` argument was supplied. This has been fixed.
-
 ## 2.0.4 (2023-10-10)
 
 ### Trivial
 
-  - Improve base type annotations, avoid type annotations in comments [Maxwell Muoto, 862e253]
+-   Improve base type annotations, avoid type annotations in comments [Maxwell Muoto, 862e253]
 
 ## 2.0.3 (2023-10-09)
 
 ### Trivial
 
-  - Added Opus10 branding to docs [Wesley Kendall, c2f9d18]
+-   Added Opus10 branding to docs [Wesley Kendall, c2f9d18]
 
 ## 2.0.2 (2023-10-08)
 
 ### Trivial
 
-  - Add additional docs and notes around async usaged and model signals. [Wesley Kendall, 4cce843]
+-   Add additional docs and notes around async usaged and model signals. [Wesley Kendall, 4cce843]
 
 ## 2.0.1 (2023-10-08)
 
 ### Trivial
 
-  - Fix release notes [Wesley Kendall, 8a88b7a]
+-   Fix release notes [Wesley Kendall, 8a88b7a]
 
 ## 2.0.0 (2023-10-08)
 
 ### Api-Break
 
-  - Python 3.12 / async support, dropping of `pgbulk.sync` and `return_untouched` [Wesley Kendall, de70607]
+-   Python 3.12 / async support, dropping of `pgbulk.sync` and `return_untouched` [Wesley Kendall, de70607]
 
     This version of `django-pgbulk` breaks the API in the following manner:
 
-    - `pgbulk.upsert` no longer supports the `return_untouched` argument. It had race conditions and will only be brought back if those race conditions can be addressed.
-    - `pgbulk.upsert`'s `ignore_duplicate_updates` was renamed to `redundant_updates`. The default functionality is still the same, but the argument now has the opposite meaning.
-    - `pgbulk.sync` was dropped since it relied on the `return_untouched` argument.
+    -   `pgbulk.upsert` no longer supports the `return_untouched` argument. It had race conditions and will only be brought back if those race conditions can be addressed.
+    -   `pgbulk.upsert`'s `ignore_duplicate_updates` was renamed to `redundant_updates`. The default functionality is still the same, but the argument now has the opposite meaning.
+    -   `pgbulk.sync` was dropped since it relied on the `return_untouched` argument.
 
     This release also includes the following changes:
 
-    - Python 3.12 is supported and Python 3.7 is dropped
-    - Postgres 16 support
-    - Async-compatible `pgbulk.aupsert` and `pgbulk.aupdate` were added
-    - New documentation theme and formatting with Material for Mkdocs
-    - Type annotations for public functions and classes
+    -   Python 3.12 is supported and Python 3.7 is dropped
+    -   Postgres 16 support
+    -   Async-compatible `pgbulk.aupsert` and `pgbulk.aupdate` were added
+    -   New documentation theme and formatting with Material for Mkdocs
+    -   Type annotations for public functions and classes
 
 ## 1.4.0 (2023-06-08)
 
 ### Feature
 
-  - Added Python 3.11, Django 4.2, and Psycopg 3 support [Wesley Kendall, f606b0b]
+-   Added Python 3.11, Django 4.2, and Psycopg 3 support [Wesley Kendall, f606b0b]
 
     Adds Python 3.11, Django 4.2, and Psycopg 3 support along with tests for multiple Postgres versions. Drops support for Django 2.2.
 
@@ -79,112 +56,112 @@
 
 ### Feature
 
-  - Sort bulk update objects [Wesley Kendall, f766617]
+-   Sort bulk update objects [Wesley Kendall, f766617]
 
-    Objects passed to ``pgbulk.update`` are now sorted to reduce the likelihood of
+    Objects passed to `pgbulk.update` are now sorted to reduce the likelihood of
     a deadlock when executed concurrently.
 
 ### Trivial
 
-  - Updated with latest Python template [Wesley Kendall, 9652cd2]
-  - Updated with latest Django template [Wesley Kendall, 6ef27e6]
+-   Updated with latest Python template [Wesley Kendall, 9652cd2]
+-   Updated with latest Django template [Wesley Kendall, 6ef27e6]
 
 ## 1.2.6 (2022-08-26)
 
 ### Trivial
 
-  - Test against Django 4.1 and other CI improvements [Wes Kendall, 9eedff4]
+-   Test against Django 4.1 and other CI improvements [Wes Kendall, 9eedff4]
 
 ## 1.2.5 (2022-08-24)
 
 ### Trivial
 
-  - Fix ReadTheDocs builds [Wes Kendall, 15832a5]
+-   Fix ReadTheDocs builds [Wes Kendall, 15832a5]
 
 ## 1.2.4 (2022-08-20)
 
 ### Trivial
 
-  - Updated with latest Django template [Wes Kendall, 4e9e095]
+-   Updated with latest Django template [Wes Kendall, 4e9e095]
 
 ## 1.2.3 (2022-08-20)
 
 ### Trivial
 
-  - Fix release note rendering and code formatting changes [Wes Kendall, 94f1192]
+-   Fix release note rendering and code formatting changes [Wes Kendall, 94f1192]
 
 ## 1.2.2 (2022-08-17)
 
 ### Trivial
 
-  - README and intro documentation fix [Wes Kendall, e75930e]
+-   README and intro documentation fix [Wes Kendall, e75930e]
 
 ## 1.2.1 (2022-07-31)
 
 ### Trivial
 
-  - Updated with latest Django template, fixing doc builds [Wes Kendall, c3ed424]
+-   Updated with latest Django template, fixing doc builds [Wes Kendall, c3ed424]
 
 ## 1.2.0 (2022-03-14)
 
 ### Feature
 
-  - Handle func-based fields and allow expressions in upserts [Wes Kendall, 64458c5]
+-   Handle func-based fields and allow expressions in upserts [Wes Kendall, 64458c5]
 
-    ``pgbulk.upsert`` allows users to provide a ``pgbulk.UpdateField`` object
-    to the ``update_fields`` argument, allowing a users to specify an expression
+    `pgbulk.upsert` allows users to provide a `pgbulk.UpdateField` object
+    to the `update_fields` argument, allowing a users to specify an expression
     that happens if an update occurs.
 
-    This allows, for example, a user to do ``models.F('my_field') + 1`` and
-    increment integer fields in a ``pgbulk.upsert``.
+    This allows, for example, a user to do `models.F('my_field') + 1` and
+    increment integer fields in a `pgbulk.upsert`.
 
-    Along with this, fields that cast to ``Func`` and other expressions are
+    Along with this, fields that cast to `Func` and other expressions are
     properly handled during upsert.
 
 ## 1.1.1 (2022-03-14)
 
 ### Trivial
 
-  - Updates to latest template, dropping py3.6 support and adding Django4 support [Wes Kendall, 35a04b0]
+-   Updates to latest template, dropping py3.6 support and adding Django4 support [Wes Kendall, 35a04b0]
 
 ## 1.1.0 (2022-01-08)
 
 ### Bug
 
-  - Fix error when upserting custom AutoFields [Wes Kendall, 114eb45]
+-   Fix error when upserting custom AutoFields [Wes Kendall, 114eb45]
 
-    ``upsert()`` previously errored when using a custom auto-incrementing field. This
+    `upsert()` previously errored when using a custom auto-incrementing field. This
     has been tested and fixed.
 
 ## 1.0.2 (2021-06-06)
 
 ### Trivial
 
-  - Updated with the latest Django template [Wes Kendall, 71a2678]
+-   Updated with the latest Django template [Wes Kendall, 71a2678]
 
 ## 1.0.1 (2020-06-29)
 
 ### Trivial
 
-  - Update with the latest public django app template. [Wes Kendall, 271b456]
+-   Update with the latest public django app template. [Wes Kendall, 271b456]
 
 ## 1.0.0 (2020-06-27)
 
 ### Api-Break
 
-  - Initial release of django-pgbulk. [Wes Kendall, 7070a26]
+-   Initial release of django-pgbulk. [Wes Kendall, 7070a26]
 
     The initial release of django-pgbulk includes three functions for
     bulk operations in postgres:
 
-    1. ``pgbulk.update`` - For updating a list of models in bulk. Although Django
-       provides a ``bulk_update`` in 2.2, it performs individual updates for
+    1. `pgbulk.update` - For updating a list of models in bulk. Although Django
+       provides a `bulk_update` in 2.2, it performs individual updates for
        every row and does not perform a native bulk update.
-    2. ``pgbulk.upsert`` - For doing a bulk update or insert. This function uses
-       postgres ``UPDATE ON CONFLICT`` syntax to perform an atomic upsert
+    2. `pgbulk.upsert` - For doing a bulk update or insert. This function uses
+       postgres `UPDATE ON CONFLICT` syntax to perform an atomic upsert
        operation. There are several options to this function that allow the
        user to avoid touching rows if they result in a duplicate update, along
        with returning which rows were updated, created, or untouched.
-    3. ``pgbulk.sync`` - For syncing a list of models with a table. Does a bulk
+    3. `pgbulk.sync` - For syncing a list of models with a table. Does a bulk
        upsert and also deletes any rows in the source queryset that were not
        part of the input data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.4 (2023-10-10)
+
+### Trivial
+
+  - Improve base type annotations, avoid type annotations in comments [Maxwell Muoto, 862e253]
+
 ## 2.0.3 (2023-10-09)
 
 ### Trivial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.1.0 (2023-11-03)
+
+### Bug
+
+  - Allow updates on custom primary key fields [Wesley Kendall, 4dbfb1c]
+
+    `pgbulk.update` would fail on models with custom primary key fields when
+    no `update_fields` argument was supplied. This has been fixed.
+
 ## 2.0.4 (2023-10-10)
 
 ### Trivial

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Do a bulk update on a model:
 
 ## Compatibility
 
-`django-pgbulk` is compatible with Python 3.8 - 3.12, Django 3.2 - 4.2, Psycopg 2 - 3, and Postgres 12 - 16.
+`django-pgbulk` is compatible with Python 3.8 - 3.12, Django 3.2 - 5.0, Psycopg 2 - 3, and Postgres 12 - 16.
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ Do a bulk update on a model:
 
 ## Compatibility
 
-`django-pgbulk` is compatible with Python 3.8 - 3.12, Django 3.2 - 4.2, Psycopg 2 - 3, and Postgres 12 - 16.
+`django-pgbulk` is compatible with Python 3.8 - 3.12, Django 3.2 - 5.0, Psycopg 2 - 3, and Postgres 12 - 16.
 
 ## Next Steps
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,7 +4,7 @@
 
 ### Feature
 
-  - Django 5.0 compatibility [Wesley Kendall, e7848ed]
+-   Django 5.0 compatibility [Wesley Kendall, e7848ed]
 
     Support and test against Django 5 with psycopg2 and psycopg3.
 
@@ -12,13 +12,13 @@
 
 ### Trivial
 
-  - Add py.typed file, fix typing issues [Maxwell Muoto, 76f6e77]
+-   Add py.typed file, fix typing issues [Maxwell Muoto, 76f6e77]
 
 ## 2.1.0 (2023-11-03)
 
 ### Bug
 
-  - Allow updates on custom primary key fields [Wesley Kendall, 4dbfb1c]
+-   Allow updates on custom primary key fields [Wesley Kendall, 4dbfb1c]
 
     `pgbulk.update` would fail on models with custom primary key fields when
     no `update_fields` argument was supplied. This has been fixed.
@@ -27,51 +27,51 @@
 
 ### Trivial
 
-  - Improve base type annotations, avoid type annotations in comments [Maxwell Muoto, 862e253]
+-   Improve base type annotations, avoid type annotations in comments [Maxwell Muoto, 862e253]
 
 ## 2.0.3 (2023-10-09)
 
 ### Trivial
 
-  - Added Opus10 branding to docs [Wesley Kendall, c2f9d18]
+-   Added Opus10 branding to docs [Wesley Kendall, c2f9d18]
 
 ## 2.0.2 (2023-10-08)
 
 ### Trivial
 
-  - Add additional docs and notes around async usaged and model signals. [Wesley Kendall, 4cce843]
+-   Add additional docs and notes around async usaged and model signals. [Wesley Kendall, 4cce843]
 
 ## 2.0.1 (2023-10-08)
 
 ### Trivial
 
-  - Fix release notes [Wesley Kendall, 8a88b7a]
+-   Fix release notes [Wesley Kendall, 8a88b7a]
 
 ## 2.0.0 (2023-10-08)
 
 ### Api-Break
 
-  - Python 3.12 / async support, dropping of `pgbulk.sync` and `return_untouched` [Wesley Kendall, de70607]
+-   Python 3.12 / async support, dropping of `pgbulk.sync` and `return_untouched` [Wesley Kendall, de70607]
 
     This version of `django-pgbulk` breaks the API in the following manner:
 
-    - `pgbulk.upsert` no longer supports the `return_untouched` argument. It had race conditions and will only be brought back if those race conditions can be addressed.
-    - `pgbulk.upsert`'s `ignore_duplicate_updates` was renamed to `redundant_updates`. The default functionality is still the same, but the argument now has the opposite meaning.
-    - `pgbulk.sync` was dropped since it relied on the `return_untouched` argument.
+    -   `pgbulk.upsert` no longer supports the `return_untouched` argument. It had race conditions and will only be brought back if those race conditions can be addressed.
+    -   `pgbulk.upsert`'s `ignore_duplicate_updates` was renamed to `redundant_updates`. The default functionality is still the same, but the argument now has the opposite meaning.
+    -   `pgbulk.sync` was dropped since it relied on the `return_untouched` argument.
 
     This release also includes the following changes:
 
-    - Python 3.12 is supported and Python 3.7 is dropped
-    - Postgres 16 support
-    - Async-compatible `pgbulk.aupsert` and `pgbulk.aupdate` were added
-    - New documentation theme and formatting with Material for Mkdocs
-    - Type annotations for public functions and classes
+    -   Python 3.12 is supported and Python 3.7 is dropped
+    -   Postgres 16 support
+    -   Async-compatible `pgbulk.aupsert` and `pgbulk.aupdate` were added
+    -   New documentation theme and formatting with Material for Mkdocs
+    -   Type annotations for public functions and classes
 
 ## 1.4.0 (2023-06-08)
 
 ### Feature
 
-  - Added Python 3.11, Django 4.2, and Psycopg 3 support [Wesley Kendall, f606b0b]
+-   Added Python 3.11, Django 4.2, and Psycopg 3 support [Wesley Kendall, f606b0b]
 
     Adds Python 3.11, Django 4.2, and Psycopg 3 support along with tests for multiple Postgres versions. Drops support for Django 2.2.
 
@@ -79,112 +79,112 @@
 
 ### Feature
 
-  - Sort bulk update objects [Wesley Kendall, f766617]
+-   Sort bulk update objects [Wesley Kendall, f766617]
 
-    Objects passed to ``pgbulk.update`` are now sorted to reduce the likelihood of
+    Objects passed to `pgbulk.update` are now sorted to reduce the likelihood of
     a deadlock when executed concurrently.
 
 ### Trivial
 
-  - Updated with latest Python template [Wesley Kendall, 9652cd2]
-  - Updated with latest Django template [Wesley Kendall, 6ef27e6]
+-   Updated with latest Python template [Wesley Kendall, 9652cd2]
+-   Updated with latest Django template [Wesley Kendall, 6ef27e6]
 
 ## 1.2.6 (2022-08-26)
 
 ### Trivial
 
-  - Test against Django 4.1 and other CI improvements [Wes Kendall, 9eedff4]
+-   Test against Django 4.1 and other CI improvements [Wes Kendall, 9eedff4]
 
 ## 1.2.5 (2022-08-24)
 
 ### Trivial
 
-  - Fix ReadTheDocs builds [Wes Kendall, 15832a5]
+-   Fix ReadTheDocs builds [Wes Kendall, 15832a5]
 
 ## 1.2.4 (2022-08-20)
 
 ### Trivial
 
-  - Updated with latest Django template [Wes Kendall, 4e9e095]
+-   Updated with latest Django template [Wes Kendall, 4e9e095]
 
 ## 1.2.3 (2022-08-20)
 
 ### Trivial
 
-  - Fix release note rendering and code formatting changes [Wes Kendall, 94f1192]
+-   Fix release note rendering and code formatting changes [Wes Kendall, 94f1192]
 
 ## 1.2.2 (2022-08-17)
 
 ### Trivial
 
-  - README and intro documentation fix [Wes Kendall, e75930e]
+-   README and intro documentation fix [Wes Kendall, e75930e]
 
 ## 1.2.1 (2022-07-31)
 
 ### Trivial
 
-  - Updated with latest Django template, fixing doc builds [Wes Kendall, c3ed424]
+-   Updated with latest Django template, fixing doc builds [Wes Kendall, c3ed424]
 
 ## 1.2.0 (2022-03-14)
 
 ### Feature
 
-  - Handle func-based fields and allow expressions in upserts [Wes Kendall, 64458c5]
+-   Handle func-based fields and allow expressions in upserts [Wes Kendall, 64458c5]
 
-    ``pgbulk.upsert`` allows users to provide a ``pgbulk.UpdateField`` object
-    to the ``update_fields`` argument, allowing a users to specify an expression
+    `pgbulk.upsert` allows users to provide a `pgbulk.UpdateField` object
+    to the `update_fields` argument, allowing a users to specify an expression
     that happens if an update occurs.
 
-    This allows, for example, a user to do ``models.F('my_field') + 1`` and
-    increment integer fields in a ``pgbulk.upsert``.
+    This allows, for example, a user to do `models.F('my_field') + 1` and
+    increment integer fields in a `pgbulk.upsert`.
 
-    Along with this, fields that cast to ``Func`` and other expressions are
+    Along with this, fields that cast to `Func` and other expressions are
     properly handled during upsert.
 
 ## 1.1.1 (2022-03-14)
 
 ### Trivial
 
-  - Updates to latest template, dropping py3.6 support and adding Django4 support [Wes Kendall, 35a04b0]
+-   Updates to latest template, dropping py3.6 support and adding Django4 support [Wes Kendall, 35a04b0]
 
 ## 1.1.0 (2022-01-08)
 
 ### Bug
 
-  - Fix error when upserting custom AutoFields [Wes Kendall, 114eb45]
+-   Fix error when upserting custom AutoFields [Wes Kendall, 114eb45]
 
-    ``upsert()`` previously errored when using a custom auto-incrementing field. This
+    `upsert()` previously errored when using a custom auto-incrementing field. This
     has been tested and fixed.
 
 ## 1.0.2 (2021-06-06)
 
 ### Trivial
 
-  - Updated with the latest Django template [Wes Kendall, 71a2678]
+-   Updated with the latest Django template [Wes Kendall, 71a2678]
 
 ## 1.0.1 (2020-06-29)
 
 ### Trivial
 
-  - Update with the latest public django app template. [Wes Kendall, 271b456]
+-   Update with the latest public django app template. [Wes Kendall, 271b456]
 
 ## 1.0.0 (2020-06-27)
 
 ### Api-Break
 
-  - Initial release of django-pgbulk. [Wes Kendall, 7070a26]
+-   Initial release of django-pgbulk. [Wes Kendall, 7070a26]
 
     The initial release of django-pgbulk includes three functions for
     bulk operations in postgres:
 
-    1. ``pgbulk.update`` - For updating a list of models in bulk. Although Django
-       provides a ``bulk_update`` in 2.2, it performs individual updates for
+    1. `pgbulk.update` - For updating a list of models in bulk. Although Django
+       provides a `bulk_update` in 2.2, it performs individual updates for
        every row and does not perform a native bulk update.
-    2. ``pgbulk.upsert`` - For doing a bulk update or insert. This function uses
-       postgres ``UPDATE ON CONFLICT`` syntax to perform an atomic upsert
+    2. `pgbulk.upsert` - For doing a bulk update or insert. This function uses
+       postgres `UPDATE ON CONFLICT` syntax to perform an atomic upsert
        operation. There are several options to this function that allow the
        user to avoid touching rows if they result in a duplicate update, along
        with returning which rows were updated, created, or untouched.
-    3. ``pgbulk.sync`` - For syncing a list of models with a table. Does a bulk
+    3. `pgbulk.sync` - For syncing a list of models with a table. Does a bulk
        upsert and also deletes any rows in the source queryset that were not
        part of the input data.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## 2.2.0 (2023-11-26)
-
-### Feature
-
--   Django 5.0 compatibility [Wesley Kendall, e7848ed]
-
-    Support and test against Django 5 with psycopg2 and psycopg3.
-
-## 2.1.1 (2023-11-23)
-
-### Trivial
-
--   Add py.typed file, fix typing issues [Maxwell Muoto, 76f6e77]
-
 ## 2.1.0 (2023-11-03)
 
 ### Bug

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.2.0 (2023-11-26)
+
+### Feature
+
+  - Django 5.0 compatibility [Wesley Kendall, e7848ed]
+
+    Support and test against Django 5 with psycopg2 and psycopg3.
+
+## 2.1.1 (2023-11-23)
+
+### Trivial
+
+  - Add py.typed file, fix typing issues [Maxwell Muoto, 76f6e77]
+
 ## 2.1.0 (2023-11-03)
 
 ### Bug

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.3 (2023-10-09)
+
+### Trivial
+
+  - Added Opus10 branding to docs [Wesley Kendall, c2f9d18]
+
 ## 2.0.2 (2023-10-08)
 
 ### Trivial

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.4 (2023-10-10)
+
+### Trivial
+
+  - Improve base type annotations, avoid type annotations in comments [Maxwell Muoto, 862e253]
+
 ## 2.0.3 (2023-10-09)
 
 ### Trivial

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.1.0 (2023-11-03)
+
+### Bug
+
+  - Allow updates on custom primary key fields [Wesley Kendall, 4dbfb1c]
+
+    `pgbulk.update` would fail on models with custom primary key fields when
+    no `update_fields` argument was supplied. This has been fixed.
+
 ## 2.0.4 (2023-10-10)
 
 ### Trivial

--- a/footing.yaml
+++ b/footing.yaml
@@ -1,7 +1,7 @@
 _extensions:
 - jinja2_time.TimeExtension
 _template: git@github.com:Opus10/public-django-app-template.git
-_version: 61fb54bab32508ca0cc5d70a9155f49d124f04c0
+_version: a2f39d5ad54f2ef63172d2b43756a85ec66eb12e
 module_name: pgbulk
 repo_name: django-pgbulk
 short_description: Native postgres bulk update and upsert operations.

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -1,6 +1,6 @@
 import itertools
 from collections import UserString, namedtuple
-from typing import List, Union
+from typing import Iterable, List, Union
 
 from asgiref.sync import sync_to_async
 from django.core.exceptions import ImproperlyConfigured
@@ -8,6 +8,10 @@ from django.db import connections, models
 from django.db.models.sql.compiler import SQLCompiler
 from django.utils import timezone
 from django.utils.version import get_version_tuple
+
+UpdateFieldsTypeDef = Union[
+    List[str], List["UpsertResult"], List[Union["UpsertResult", str]], None
+]
 
 
 def _psycopg_version():
@@ -357,33 +361,33 @@ def _fetch(
 
 
 def _upsert(
-    queryset,
-    model_objs,
-    unique_fields,
-    update_fields=None,
-    returning=False,
-    redundant_updates=False,
+    queryset: Union[models.Model, models.QuerySet],
+    model_objs: Iterable[models.Model],
+    unique_fields: List[str],
+    update_fields: UpdateFieldsTypeDef = None,
+    returning: Union[List[str], bool] = False,
+    redundant_updates: bool = False,
 ):
     """
     Perform a bulk upsert on a table
 
     Args:
-        queryset (Model|QuerySet): A model or a queryset that defines the
+        queryset: A model or a queryset that defines the
             collection to upsert.
-        model_objs (List[Model]): A list of Django models to upsert.
-        unique_fields (List[str]): A list of fields that define the uniqueness
+        model_objs: An iterable of Django models to upsert.
+        unique_fields: A list of fields that define the uniqueness
             of the model. The model must have a unique constraint on these
             fields.
-        update_fields (List[str], default=None): A list of fields to update
+        update_fields: A list of fields to update
             whenever objects already exist. If an empty list is provided, it
             is equivalent to doing a bulk insert on the objects that don't
             exist. If `None`, all fields will be updated. If you want to
             perform an expression such as an `F` object on a field when
             it is updated, use the [pgbulk.UpdateField][] class. See
             examples below.
-        returning (bool|List[str]): If True, returns all fields. If a list,
+        returning: If True, returns all fields. If a list,
             only returns fields in the list.
-        redundant_updates (bool, default=False): Don't perform an update
+        redundant_updates: Don't perform an update
             if all columns are identical to the row in the database.
     """
     queryset = queryset if isinstance(queryset, models.QuerySet) else queryset.objects.all()
@@ -407,8 +411,8 @@ def _upsert(
 
 def update(
     queryset: Union[models.Model, models.QuerySet],
-    model_objs: List[models.Model],
-    update_fields: Union[List[str], None] = None,
+    model_objs: Iterable[models.Model],
+    update_fields: UpdateFieldsTypeDef = None,
 ) -> None:
     """
     Performs a bulk update.
@@ -515,8 +519,8 @@ def update(
 
 async def aupdate(
     queryset: Union[models.Model, models.QuerySet],
-    model_objs: List[models.Model],
-    update_fields: Union[List[str], None] = None,
+    model_objs: Iterable[models.Model],
+    update_fields: UpdateFieldsTypeDef = None,
 ) -> None:
     """
     Perform an asynchronous bulk update.
@@ -533,9 +537,9 @@ async def aupdate(
 
 def upsert(
     queryset: Union[models.Model, models.QuerySet],
-    model_objs: List[models.Model],
+    model_objs: Iterable[models.Model],
     unique_fields: List[str],
-    update_fields: Union[List[str], None] = None,
+    update_fields: UpdateFieldsTypeDef = None,
     *,
     returning: Union[List[str], bool] = False,
     redundant_updates: bool = False,
@@ -546,7 +550,7 @@ def upsert(
     Args:
         queryset: A model or a queryset that defines the
             collection to upsert
-        model_objs: A list of Django models to upsert. All models
+        model_objs: An iterable of Django models to upsert. All models
             in this list will be bulk upserted.
         unique_fields: A list of fields that define the uniqueness
             of the model. The model must have a unique constraint on these
@@ -661,9 +665,9 @@ def upsert(
 
 async def aupsert(
     queryset: Union[models.Model, models.QuerySet],
-    model_objs: List[models.Model],
+    model_objs: Iterable[models.Model],
     unique_fields: List[str],
-    update_fields: Union[List[str], None] = None,
+    update_fields: UpdateFieldsTypeDef = None,
     *,
     returning: Union[List[str], bool] = False,
     redundant_updates: bool = False,

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -1,6 +1,6 @@
 import itertools
 from collections import UserString, namedtuple
-from typing import Iterable, List, Union
+from typing import Iterable, List, Type, Union
 
 from asgiref.sync import sync_to_async
 from django.core.exceptions import ImproperlyConfigured
@@ -111,8 +111,7 @@ def _get_update_fields(queryset, to_update, exclude=None):
     """
     Get the fields to be updated in an upsert.
 
-    Always exclude auto_now_add, auto_created fields, and unique fields in an
-    update
+    Always exclude auto_now_add and primary key fields
     """
     exclude = exclude or []
     model = queryset.model
@@ -130,7 +129,7 @@ def _get_update_fields(queryset, to_update, exclude=None):
         if (
             attname not in exclude
             and not getattr(fields[attname], "auto_now_add", False)
-            and not fields[attname].auto_created
+            and not fields[attname].primary_key
         )
     ]
 
@@ -361,7 +360,7 @@ def _fetch(
 
 
 def _upsert(
-    queryset: Union[models.Model, models.QuerySet],
+    queryset: Union[Type[models.Model], models.QuerySet],
     model_objs: Iterable[models.Model],
     unique_fields: List[str],
     update_fields: UpdateFieldsTypeDef = None,
@@ -410,7 +409,7 @@ def _upsert(
 
 
 def update(
-    queryset: Union[models.Model, models.QuerySet],
+    queryset: Union[Type[models.Model], models.QuerySet],
     model_objs: Iterable[models.Model],
     update_fields: UpdateFieldsTypeDef = None,
 ) -> None:
@@ -518,7 +517,7 @@ def update(
 
 
 async def aupdate(
-    queryset: Union[models.Model, models.QuerySet],
+    queryset: Union[Type[models.Model], models.QuerySet],
     model_objs: Iterable[models.Model],
     update_fields: UpdateFieldsTypeDef = None,
 ) -> None:
@@ -536,7 +535,7 @@ async def aupdate(
 
 
 def upsert(
-    queryset: Union[models.Model, models.QuerySet],
+    queryset: Union[Type[models.Model], models.QuerySet],
     model_objs: Iterable[models.Model],
     unique_fields: List[str],
     update_fields: UpdateFieldsTypeDef = None,
@@ -664,7 +663,7 @@ def upsert(
 
 
 async def aupsert(
-    queryset: Union[models.Model, models.QuerySet],
+    queryset: Union[Type[models.Model], models.QuerySet],
     model_objs: Iterable[models.Model],
     unique_fields: List[str],
     update_fields: UpdateFieldsTypeDef = None,

--- a/pgbulk/tests/test_core.py
+++ b/pgbulk/tests/test_core.py
@@ -726,6 +726,7 @@ def test_upsert_some_updates_unique_int_char_field_queryset():
 
 
 @pytest.mark.django_db
+<<<<<<< HEAD
 def test_upsert_objs_with_excluded_fields():
     """
     Tests that we properly exclude fields when upserting
@@ -759,6 +760,8 @@ def test_upsert_objs_with_excluded_fields():
 
 
 @pytest.mark.django_db
+=======
+>>>>>>> 4dbfb1c (Allow updates on custom primary key fields)
 def test_update_custom_auto_field():
     t_model = ddf.G(models.TestAutoFieldModel)
     pgbulk.update(models.TestAutoFieldModel, [t_model])

--- a/pgbulk/tests/test_core.py
+++ b/pgbulk/tests/test_core.py
@@ -727,6 +727,9 @@ def test_upsert_some_updates_unique_int_char_field_queryset():
 
 @pytest.mark.django_db
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> f76b98a (Add exclude field for update and upsert.)
 def test_upsert_objs_with_excluded_fields():
     """
     Tests that we properly exclude fields when upserting
@@ -760,8 +763,11 @@ def test_upsert_objs_with_excluded_fields():
 
 
 @pytest.mark.django_db
+<<<<<<< HEAD
 =======
 >>>>>>> 4dbfb1c (Allow updates on custom primary key fields)
+=======
+>>>>>>> f76b98a (Add exclude field for update and upsert.)
 def test_update_custom_auto_field():
     t_model = ddf.G(models.TestAutoFieldModel)
     pgbulk.update(models.TestAutoFieldModel, [t_model])

--- a/pgbulk/tests/test_core.py
+++ b/pgbulk/tests/test_core.py
@@ -726,6 +726,12 @@ def test_upsert_some_updates_unique_int_char_field_queryset():
 
 
 @pytest.mark.django_db
+def test_update_custom_auto_field():
+    t_model = ddf.G(models.TestAutoFieldModel)
+    pgbulk.update(models.TestAutoFieldModel, [t_model])
+
+
+@pytest.mark.django_db
 def test_update_foreign_key_by_id():
     t_model = ddf.G(models.TestModel)
     t_fk_model = ddf.G(models.TestForeignKeyModel)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ fail_under = 100
 name = "django-pgbulk"
 packages = [{ include = "pgbulk" }]
 exclude = ["*/tests/"]
-version = "2.1.0"
+version = "2.2.0"
 description = "Native postgres bulk update and upsert operations."
 authors = ["Wes Kendall"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "2.0.2"
+version = "2.0.3"
 description = "Native postgres bulk update and upsert operations."
 authors = ["Wes Kendall"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "2.0.4"
+version = "2.1.0"
 description = "Native postgres bulk update and upsert operations."
 authors = ["Wes Kendall"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "2.0.3"
+version = "2.0.4"
 description = "Native postgres bulk update and upsert operations."
 authors = ["Wes Kendall"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "2.1.0"
+version = "2.2.0"
 description = "Native postgres bulk update and upsert operations."
 authors = ["Wes Kendall"]
 classifiers = [
@@ -38,6 +38,7 @@ classifiers = [
   "Framework :: Django :: 4.0",
   "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
+  "Framework :: Django :: 5.0",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ fail_under = 100
 name = "django-pgbulk"
 packages = [{ include = "pgbulk" }]
 exclude = ["*/tests/"]
-version = "2.0.4"
+version = "2.1.0"
 description = "Native postgres bulk update and upsert operations."
 authors = ["Wes Kendall"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,24 +12,20 @@ source = ["pgbulk"]
 
 [tool.coverage.report]
 exclude_lines = [
-    "pragma: no cover",
-    "raise AssertionError",
-    "raise NotImplementedError",
-    "pass",
-    "pytest.mark.skip"
+  "pragma: no cover",
+  "raise AssertionError",
+  "raise NotImplementedError",
+  "pass",
+  "pytest.mark.skip",
 ]
 show_missing = true
 fail_under = 100
 
 [tool.poetry]
 name = "django-pgbulk"
-packages = [
-  { include = "pgbulk" }
-]
-exclude = [
-  "*/tests/"
-]
-version = "2.2.0"
+packages = [{ include = "pgbulk" }]
+exclude = ["*/tests/"]
+version = "2.0.4"
 description = "Native postgres bulk update and upsert operations."
 authors = ["Wes Kendall"]
 classifiers = [

--- a/settings.py
+++ b/settings.py
@@ -14,3 +14,5 @@ INSTALLED_APPS = [
 DATABASES = {"default": dj_database_url.config()}
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+USE_TZ = False

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,19 @@
 [tox]
 isolated_build = true
-envlist = py{38,39,310,311,312}-django{32,42}-psycopg2,py312-django42-psycopg3,report
+envlist =
+    py{38,39,310,311,312}-django32-psycopg2
+    py{38,39,310,311,312}-django42-psycopg2
+    py312-django42-psycopg3
+    py{310,311,312}-django50-psycopg2
+    py312-django50-psycopg3
+    report
 
 [testenv]
 install_command = pip install {opts} --no-compile {packages}
 deps =
     django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3
+    django50: Django>=5.0rc1,<5.1
     psycopg2: psycopg2-binary
     psycopg3: psycopg[binary]
 allowlist_externals =
@@ -20,13 +27,13 @@ skip_install = true
 commands =
     bash -c 'poetry export --with dev --without-hashes -f requirements.txt | grep -v "^[dD]jango==" | grep -v "^psycopg2-binary==" | pip install --no-compile -q --no-deps -r /dev/stdin'
     pip install --no-compile -q --no-deps --no-build-isolation -e .
-    pytest --create-db --cov --cov-fail-under=0 --cov-append --cov-config pyproject.toml pgbulk/
+    pytest --create-db --cov --cov-fail-under=0 --cov-append --cov-config pyproject.toml {posargs}
 
 [testenv:report]
 allowlist_externals =
     coverage
 skip_install = true
-depends = py{38,39,310,311,312}-django{32,42}-psycopg2,py312-django42-psycopg3
+depends = py{38,39,310,311,312}-django{32,42}-psycopg2,py312-django42-psycopg3-py{310,311,312}-django50-psycopg2-py312-django50-psycopg3
 parallel_show_output = true
 commands =
     coverage report --fail-under 100


### PR DESCRIPTION
Add `exclude` argument to `upsert` and `update` to exclude fields. Specifically useful when updating all fields.