### PR TITLE
Fix operations on virtual and generated fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Do a bulk update on a model:
 Install `django-pgbulk` with:
 
     pip3 install django-pgbulk
+
 After this, add `pgbulk` to the `INSTALLED_APPS` setting of your Django project.
 
 ## Contributing Guide
@@ -68,3 +69,4 @@ For information on setting up django-pgbulk for development and contributing cha
 ## Other Contributors
 
 - @max-muoto
+- @dalberto

--- a/pgbulk/tests/models.py
+++ b/pgbulk/tests/models.py
@@ -1,5 +1,6 @@
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
+from django_hashids import HashidsField
 from timezone_field import TimeZoneField
 
 
@@ -55,6 +56,13 @@ class TestAutoDateTimeModel(models.Model):
     int_field = models.IntegerField(unique=True)
     auto_now_field = models.DateTimeField(auto_now=True)
     auto_now_add_field = models.DateTimeField(auto_now_add=True)
+
+
+class TestNonConcreteField(models.Model):
+    """A model to test non-concrete fields."""
+
+    hashid = HashidsField(real_field_name="id")
+    int_field = models.IntegerField(unique=True)
 
 
 class TestForeignKeyModel(models.Model):

--- a/pgbulk/tests/test_core.py
+++ b/pgbulk/tests/test_core.py
@@ -12,6 +12,23 @@ from pgbulk.tests import models
 
 
 @pytest.mark.django_db
+def test_non_concrete_field():
+    """Tests upserts and updates on non-concrete fields"""
+    upsert_results = pgbulk.upsert(
+        models.TestNonConcreteField,
+        [models.TestNonConcreteField(int_field=1)],
+        ["int_field"],
+        returning=True,
+    )
+    assert len(upsert_results.created) == 1
+    assert not upsert_results.updated
+
+    non_concrete = models.TestNonConcreteField.objects.get()
+    non_concrete.int_field = 2
+    pgbulk.update(models.TestNonConcreteField, [non_concrete])
+
+
+@pytest.mark.django_db
 def test_func_field_upsert():
     """Tests the effects of setting a field to upsert using an F object"""
     models.TestFuncFieldModel.objects.create(my_key="a", int_val=0)

--- a/poetry.lock
+++ b/poetry.lock
@@ -460,6 +460,20 @@ files = [
 ]
 
 [[package]]
+name = "django-hashids"
+version = "0.7.0"
+description = "Non-intrusive hashids library for Django"
+optional = false
+python-versions = ">=3.6.2,<4"
+files = [
+    {file = "django_hashids-0.7.0-py3-none-any.whl", hash = "sha256:a5d91bda97c46afa08972d9e85143af79d9e2f8d754f3d3f0df6b8ac8f57b92b"},
+    {file = "django_hashids-0.7.0.tar.gz", hash = "sha256:dce33e6f002308cbe03ca9ec80e27ce6b469e3abf2a42df8ba3381724683690b"},
+]
+
+[package.dependencies]
+hashids = ">=1.0.2"
+
+[[package]]
 name = "django-stubs"
 version = "4.2.7"
 description = "Mypy stubs for Django"
@@ -642,6 +656,20 @@ files = [
 [package.dependencies]
 astunparse = {version = ">=1.6", markers = "python_version < \"3.9\""}
 colorama = ">=0.4"
+
+[[package]]
+name = "hashids"
+version = "1.3.1"
+description = "Implements the hashids algorithm in python. For more information, visit http://hashids.org/"
+optional = false
+python-versions = ">=2.7"
+files = [
+    {file = "hashids-1.3.1-py2.py3-none-any.whl", hash = "sha256:8bddd1acba501bfc9306e7e5a99a1667f4f2cacdc20cbd70bcc5ddfa5147c94c"},
+    {file = "hashids-1.3.1.tar.gz", hash = "sha256:6c3dc775e65efc2ce2c157a65acb776d634cb814598f406469abef00ae3f635c"},
+]
+
+[package.extras]
+test = ["pytest (>=2.1.0)"]
 
 [[package]]
 name = "idna"
@@ -1901,4 +1929,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0,<4"
-content-hash = "ddc4c1d9e66d7db92c7370283519d8372e57314d630721633336920570527da2"
+content-hash = "1eb99166fd8b3b1dd5decbcfefc5a546028ce91fabcef9050298b3b6675f8129"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dj-database-url = "2.1.0"
 psycopg2-binary = "2.9.9"
 pytest-django = "4.5.2"
 django-dynamic-fixture = "4.0.1"
+django-hashids = "0.7.0"
 
 [tool.pytest.ini_options]
 xfail_strict = true

--- a/settings.py
+++ b/settings.py
@@ -16,3 +16,5 @@ DATABASES = {"default": dj_database_url.config()}
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 USE_TZ = False
+
+DJANGO_HASHIDS_SALT = "salt"


### PR DESCRIPTION
Using non-concrete fields such as django-hashids HashidsField and the new Generatedfield in Django 5 previously produced errors during upsert and update operations. These fields are now fully supported.

Type: bug

Closing #30 in favor of this. I verified that this fix also works for generated fields.

Made sure to mark @dalberto as the author of the commit so that they are properly attributed in the commit history / release notes.

Addresses #29 