### PR TITLE
`pgbulk.update` feature parity with `pgbulk.upsert`. Change behavior of `redundant_updates` argument.

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -87,7 +87,7 @@ pgbulk.upsert(
     ],
     ["int_field"],
     ["some_attr"],
-    ignore_identical=True
+    ignore_unchanged=True
 )
 ```
 
@@ -156,7 +156,7 @@ print(results[0].int_field)
 
 #### Don't apply updates if the rows are identical
 
-Use `ignore_identical=True` to avoid identical updates:
+Use `ignore_unchanged=True` to avoid identical updates:
 
 ```python
 pgbulk.upsert(
@@ -166,7 +166,7 @@ pgbulk.upsert(
         MyModel(int_field=2, some_attr="some_val2"),
     ],
     ["int_field"],
-    ignore_identical=True
+    ignore_unchanged=True
 )
 ```
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,3 +1,175 @@
 # User Guide
 
-::: pgbulk
+`django-pgbulk` comes with the following functions:
+
+- Use [pgbulk.upsert][] to do a native Postgres `INSERT ON CONFLICT` statement.
+- Use [pgbulk.update][] to do a native Postgres bulk `UPDATE` statement.
+- Use [pgbulk.aupsert][] or [pgbulk.aupdate][] for async versions of these functions.
+
+Below we show examples and advanced functionality.
+
+## Using `pgbulk.upsert`
+
+#### A basic bulk upsert on a model
+
+```python
+import pgbulk
+
+pgbulk.upsert(
+    MyModel,
+    [
+        MyModel(int_field=1, some_attr="some_val1"),
+        MyModel(int_field=2, some_attr="some_val2"),
+    ],
+    # These are the fields that identify the uniqueness constraint.
+    ["int_field"],
+    # These are the fields that will be updated if the row already
+    # exists. If not provided, all fields will be updated
+    ["some_attr"]
+)
+```
+
+#### Return the results of an upsert
+
+```python
+results = pgbulk.upsert(
+    MyModel,
+    [
+        MyModel(int_field=1, some_attr="some_val1"),
+        MyModel(int_field=2, some_attr="some_val2"),
+    ],
+    ["int_field"],
+    ["some_attr"],
+    # `True` will return all columns. One can also explicitly
+    # list which columns will be returned
+    returning=True
+)
+
+# Print which results were created
+print(results.created)
+
+# Print which results were updated.
+# By default, if an update results in no changes, it will not
+# be updated and will not be returned.
+print(results.updated)
+```
+
+#### Use an expression for updates.
+
+In the example, we increment `some_int_field` by one whenever an update happens. Otherwise it defaults to zero:
+
+```python
+pgbulk.upsert(
+    MyModel,
+    [
+        MyModel(some_int_field=0, some_key="a"),
+        MyModel(some_int_field=0, some_key="b")
+    ],
+    ["some_key"],
+    [
+        # Use UpdateField to specify an expression for the update.
+        pgbulk.UpdateField(
+            "some_int_field",
+            expression=models.F("some_int_field") + 1
+        )
+    ],
+)
+```
+
+#### Don't apply updates if the rows are identical
+
+```python
+pgbulk.upsert(
+    MyModel,
+    [
+        MyModel(int_field=1, some_attr="some_val1"),
+        MyModel(int_field=2, some_attr="some_val2"),
+    ],
+    ["int_field"],
+    ["some_attr"],
+    ignore_identical=True
+)
+```
+
+!!! warning
+
+    Triggers and auto-generated fields not in the update won't be applied. Identical rows also won't be returned if using `returning=True`.
+
+## Using `pgbulk.update`
+
+#### Update an attribute of multiple models in bulk
+
+```python
+import pgbulk
+
+pgbulk.update(
+    MyModel,
+    [
+        MyModel(id=1, some_attr='some_val1'),
+        MyModel(id=2, some_attr='some_val2')
+    ],
+    # These are the fields that will be updated. If not provided,
+    # all fields will be updated
+    ['some_attr']
+)
+```
+
+#### Use an expression in an update
+
+In the example, we increment `some_int_field` by one:
+
+```python
+pgbulk.update(
+    MyModel,
+    [
+        MyModel(some_int_field=0, some_key="a"),
+        MyModel(some_int_field=0, some_key="b")
+    ],
+    [
+        # Use UpdateField to specify an expression for the update.
+        pgbulk.UpdateField(
+            "some_int_field",
+            expression=models.F("some_int_field") + 1
+        )
+    ],
+)
+```
+
+#### Return the results of an update
+
+```python
+results = pgbulk.upsert(
+    MyModel,
+    [
+        MyModel(int_field=1, some_attr="some_val1"),
+        MyModel(int_field=2, some_attr="some_val2"),
+    ],
+    ["int_field", "some_attr"],
+    # `True` will return all columns. One can also explicitly
+    # list which columns will be returned.
+    returning=True
+)
+
+# Results can be accessed as a tuple
+print(results[0].int_field)
+```
+
+#### Don't apply updates if the rows are identical
+
+Use `ignore_identical=True` to avoid identical updates:
+
+```python
+pgbulk.upsert(
+    MyModel,
+    [
+        MyModel(int_field=1, some_attr="some_val1"),
+        MyModel(int_field=2, some_attr="some_val2"),
+    ],
+    ["int_field"],
+    ignore_identical=True
+)
+```
+
+!!! warning
+
+    Triggers and auto-generated fields not in the update won't be applied. Identical rows also won't be returned if using `returning=True`.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -54,7 +54,7 @@ print(results.created)
 print(results.updated)
 ```
 
-#### Use an expression for updates.
+#### Use an expression for updates
 
 In the example, we increment `some_int_field` by one whenever an update happens. Otherwise it defaults to zero:
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -76,7 +76,7 @@ pgbulk.upsert(
 )
 ```
 
-#### Don't apply updates if the rows are identical
+#### Ignore updating unchanged rows
 
 ```python
 pgbulk.upsert(
@@ -93,7 +93,7 @@ pgbulk.upsert(
 
 !!! warning
 
-    Triggers and auto-generated fields not in the update won't be applied. Identical rows also won't be returned if using `returning=True`.
+    Triggers and auto-generated fields not in the update won't be applied. Unchanged rows also won't be returned if using `returning=True`.
 
 ## Using `pgbulk.update`
 
@@ -154,9 +154,7 @@ results = pgbulk.upsert(
 print(results[0].int_field)
 ```
 
-#### Don't apply updates if the rows are identical
-
-Use `ignore_unchanged=True` to avoid identical updates:
+#### Ignore updating unchanged rows
 
 ```python
 pgbulk.upsert(
@@ -172,4 +170,4 @@ pgbulk.upsert(
 
 !!! warning
 
-    Triggers and auto-generated fields not in the update won't be applied. Identical rows also won't be returned if using `returning=True`.
+    Triggers and auto-generated fields not in the update won't be applied. Unchanged rows also won't be returned if using `returning=True`.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,3 @@
+# Reference
+
+::: pgbulk

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,5 +82,6 @@ nav:
   - Overview: index.md
   - Installation: installation.md
   - User Guide: guide.md
+  - Reference: reference.md
   - Release Notes: release_notes.md
   - Contributing Guide: contributing.md

--- a/pgbulk/__init__.py
+++ b/pgbulk/__init__.py
@@ -1,19 +1,9 @@
 """
-Bulk Postgres upsert and update functions.
-
-Briefly, these are the core functions and objects:
+Bulk Postgres upsert and update functions:
 
 - Use [pgbulk.upsert][] to do a native Postgres `INSERT ON CONFLICT` statement.
 - Use [pgbulk.update][] to do a native Postgres bulk `UPDATE` statement.
 - Use [pgbulk.aupsert][] or [pgbulk.aupdate][] for async versions of these functions.
-
-[pgbulk.upsert][] has other objects related to advanced usage:
-
-- [pgbulk.UpsertResult][] encapsulates created and updated values when using the
-  `returning` flag of [pgbulk.upsert][].
-- [pgbulk.UpdateField][] allows one to specify expressions for updating fields
-  in the upsert, for example, incrementing fields or conditionally ignoring
-  updates.
 """
 
 from pgbulk.core import UpdateField, UpsertResult, aupdate, aupsert, update, upsert

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -143,7 +143,7 @@ def _quote(field: str, cursor: "CursorWrapper") -> str:
     else:
         return (
             Escaping(cursor.connection.pgconn)  # type: ignore
-            .escape_identifier(data=field.encode())
+            .escape_identifier(field.encode())
             .decode()
         )
 

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -326,7 +326,7 @@ def _get_update_fields_sql(
 ) -> Tuple[str, str]:
     """Render the SET and WHERE clause of update for every update field.
 
-    If the WHERE clause is returned, it means we're ignoring identical updates.
+    If the WHERE clause is returned, it means we're ignoring unchanged rows.
     """
     connection = connections[queryset.db]
     model = queryset.model
@@ -607,7 +607,7 @@ def update(
             being updated.
         returning: If True, returns all fields. If a list, only returns fields
             in the list. If False, do not return results from the upsert.
-        ignore_unchanged: Ignore identical rows in updates.
+        ignore_unchanged: Ignore unchanged rows in updates.
 
     Note:
         Model signals such as `post_save` are not emitted.
@@ -688,7 +688,7 @@ def upsert(
             being updated. This is additive to the `unique_fields` list.
         returning: If True, returns all fields. If a list, only returns fields
             in the list. If False, do not return results from the upsert.
-        ignore_unchanged: Ignore identical rows in updates.
+        ignore_unchanged: Ignore unchanged rows in updates.
 
     Returns:
         If `returning=True`, the upserted result, an iterable list of all upsert objects.

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -141,7 +141,11 @@ def _quote(field: str, cursor: "CursorWrapper") -> str:
     if psycopg_maj_version == 2:
         return quote_ident(field, cursor.cursor)  # type: ignore
     else:
-        return Escaping.escape_identifier(field)  # type: ignore
+        return (
+            Escaping(cursor.connection.pgconn)  # type: ignore
+            .escape_identifier(data=field.encode("utf-8"))
+            .decode()
+        )
 
 
 def _get_update_fields(

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -143,7 +143,7 @@ def _quote(field: str, cursor: "CursorWrapper") -> str:
     else:
         return (
             Escaping(cursor.connection.pgconn)  # type: ignore
-            .escape_identifier(data=field.encode("utf-8"))
+            .escape_identifier(data=field.encode())
             .decode()
         )
 

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -295,7 +295,10 @@ def _get_values_for_rows(
 
 
 def _get_returning_sql(
-    returning: List[str], model: Type[models.Model], cursor: "CursorWrapper", include_status: bool
+    returning: Union[List[str], bool],
+    model: Type[models.Model],
+    cursor: "CursorWrapper",
+    include_status: bool,
 ) -> str:
     returning = returning if returning is not True else [f.column for f in _model_fields(model)]
     if not returning:

--- a/pgbulk/tests/test_core.py
+++ b/pgbulk/tests/test_core.py
@@ -46,7 +46,7 @@ def test_func_field_upsert():
         [models.TestFuncFieldModel(my_key="a", int_val=0)],
         ["my_key"],
         [pgbulk.UpdateField("int_val", expression=F("int_val") - 3)],
-        ignore_identical=True,
+        ignore_unchanged=True,
         returning=True,
     )
     assert models.TestFuncFieldModel.objects.count() == 1
@@ -58,7 +58,7 @@ def test_func_field_upsert():
         [models.TestFuncFieldModel(my_key="a", int_val=-2)],
         ["my_key"],
         [pgbulk.UpdateField("int_val")],
-        ignore_identical=True,
+        ignore_unchanged=True,
         returning=True,
     )
     assert models.TestFuncFieldModel.objects.count() == 1
@@ -419,7 +419,7 @@ def test_upsert_update_duplicate_fields_returning_none_updated():
         ["int_field"],
         ["char_field", "float_field"],
         returning=True,
-        ignore_identical=True,
+        ignore_unchanged=True,
     )
 
     assert list(results) == []
@@ -449,7 +449,7 @@ def test_upsert_update_duplicate_fields_returning_some_updated():
         ["int_field"],
         ["char_field", "float_field"],
         returning=["char_field"],
-        ignore_identical=True,
+        ignore_unchanged=True,
     )
 
     assert len(results.updated) == 1
@@ -889,9 +889,9 @@ def test_update_no_fields_given():
 
 
 @pytest.mark.django_db
-def test_update_returning_ignore_identical():
+def test_update_returning_ignore_unchanged():
     """
-    Tests updating with returning and with ignore_identical=True
+    Tests updating with returning and with ignore_unchanged=True
     """
     test_obj_1 = ddf.G(models.TestModel, int_field=1, float_field=2)
     test_obj_2 = ddf.G(models.TestModel, int_field=2, float_field=3)
@@ -911,7 +911,7 @@ def test_update_returning_ignore_identical():
     test_obj_1.refresh_from_db()
     test_obj_2.refresh_from_db()
     assert not pgbulk.update(
-        models.TestModel, [test_obj_2, test_obj_1], ignore_identical=True, returning=True
+        models.TestModel, [test_obj_2, test_obj_1], ignore_unchanged=True, returning=True
     )
 
     test_obj_1.int_field = 1

--- a/pgbulk/tests/test_core.py
+++ b/pgbulk/tests/test_core.py
@@ -912,6 +912,31 @@ def test_update_ignore_identical():
 
 
 @pytest.mark.django_db
+def test_update_expressions():
+    """
+    Tests updating with expressions
+    """
+    test_obj_1 = ddf.G(models.TestModel, int_field=1, float_field=2)
+    test_obj_2 = ddf.G(models.TestModel, int_field=2, float_field=3)
+
+    pgbulk.update(
+        models.TestModel,
+        [test_obj_1, test_obj_2],
+        [
+            pgbulk.UpdateField("int_field", expression=F("int_field") + 1),
+            pgbulk.UpdateField("float_field", expression=F("float_field") + 2),
+        ],
+    )
+
+    test_obj_1 = models.TestModel.objects.get(id=test_obj_1.id)
+    test_obj_2 = models.TestModel.objects.get(id=test_obj_2.id)
+    assert test_obj_1.int_field == 2
+    assert test_obj_1.float_field == 4
+    assert test_obj_2.int_field == 3
+    assert test_obj_2.float_field == 5
+
+
+@pytest.mark.django_db
 def test_update_floats_to_null():
     """
     Tests updating a float field to a null field.

--- a/pgbulk/tests/test_core.py
+++ b/pgbulk/tests/test_core.py
@@ -917,7 +917,7 @@ def test_update_expressions():
     Tests updating with expressions
     """
     test_obj_1 = ddf.G(models.TestModel, int_field=1, float_field=2)
-    test_obj_2 = ddf.G(models.TestModel, int_field=2, float_field=3)
+    test_obj_2 = ddf.G(models.TestModel, int_field=3, float_field=5)
 
     pgbulk.update(
         models.TestModel,
@@ -932,8 +932,8 @@ def test_update_expressions():
     test_obj_2 = models.TestModel.objects.get(id=test_obj_2.id)
     assert test_obj_1.int_field == 2
     assert test_obj_1.float_field == 4
-    assert test_obj_2.int_field == 3
-    assert test_obj_2.float_field == 5
+    assert test_obj_2.int_field == 4
+    assert test_obj_2.float_field == 7
 
 
 @pytest.mark.django_db

--- a/pgbulk/tests/test_core.py
+++ b/pgbulk/tests/test_core.py
@@ -46,7 +46,7 @@ def test_func_field_upsert():
         [models.TestFuncFieldModel(my_key="a", int_val=0)],
         ["my_key"],
         [pgbulk.UpdateField("int_val", expression=F("int_val") - 3)],
-        redundant_updates=False,
+        ignore_identical=True,
         returning=True,
     )
     assert models.TestFuncFieldModel.objects.count() == 1
@@ -58,7 +58,7 @@ def test_func_field_upsert():
         [models.TestFuncFieldModel(my_key="a", int_val=-2)],
         ["my_key"],
         [pgbulk.UpdateField("int_val")],
-        redundant_updates=False,
+        ignore_identical=True,
         returning=True,
     )
     assert models.TestFuncFieldModel.objects.count() == 1
@@ -419,7 +419,7 @@ def test_upsert_update_duplicate_fields_returning_none_updated():
         ["int_field"],
         ["char_field", "float_field"],
         returning=True,
-        redundant_updates=False,
+        ignore_identical=True,
     )
 
     assert list(results) == []
@@ -449,7 +449,7 @@ def test_upsert_update_duplicate_fields_returning_some_updated():
         ["int_field"],
         ["char_field", "float_field"],
         returning=["char_field"],
-        redundant_updates=False,
+        ignore_identical=True,
     )
 
     assert len(results.updated) == 1
@@ -482,7 +482,6 @@ def test_upsert_update_duplicate_fields_returning_some_updated_ignore_dups():
         ["int_field"],
         ["char_field", "float_field"],
         returning=["char_field"],
-        redundant_updates=True,
     )
 
     assert len(results.updated) == 3

--- a/pgbulk/tests/test_core.py
+++ b/pgbulk/tests/test_core.py
@@ -889,6 +889,29 @@ def test_update_no_fields_given():
 
 
 @pytest.mark.django_db
+def test_update_ignore_identical():
+    """
+    Tests updating when ignore_identical=True
+    """
+    test_obj_1 = ddf.G(models.TestModel, int_field=1, float_field=2)
+    test_obj_2 = ddf.G(models.TestModel, int_field=2, float_field=3)
+    test_obj_1.int_field = 7
+    test_obj_1.float_field = 8
+    test_obj_2.int_field = 9
+    test_obj_2.float_field = 10
+
+    pgbulk.update(models.TestModel, [test_obj_2, test_obj_1], ignore_identical=True)
+    pgbulk.update(models.TestModel, [test_obj_2, test_obj_1], ignore_identical=True)
+
+    test_obj_1 = models.TestModel.objects.get(id=test_obj_1.id)
+    test_obj_2 = models.TestModel.objects.get(id=test_obj_2.id)
+    assert test_obj_1.int_field == 7
+    assert test_obj_1.float_field == 8
+    assert test_obj_2.int_field == 9
+    assert test_obj_2.float_field == 10
+
+
+@pytest.mark.django_db
 def test_update_floats_to_null():
     """
     Tests updating a float field to a null field.


### PR DESCRIPTION
## `pgbulk.update` feature parity
`pgbulk.update` now supports the `returning` argument and the ability to supply expressions as update fields. It also supports ignoring unchanged rows in updates like `pgbulk.upsert`.

## `redundant_updates` and other breaking API changes
Along with this, there are four API-breaking changes worth noting:

- `pgbulk.upsert` returns `None` if `returning=False` instead of an empty list
- `pgbulk.upsert`'s `redundant_updates` argument was renamed to `ignore_unchanged`, which means the *opposite* .
- The default behavior of ignoring unchanged rows is different. Previously unchanged rows were ignored by default. This, however, caused confusion for people using `returning` to see what was updated/inserted. Users must now explicitly use `ignore_unchanged=True` to enable the previous behavior.
- `exclude`, `ignore_unchanged`, and `returning` are now keyword-only arguments

To migrate previous invocations of `pgbulk.upsert`, do the following:

1. `pgbulk.upsert(...)` without the `redundant_updates` argument should be `pgbulk.upsert(..., ignore_unchanged=True)`
2. `pgbulk.upsert(..., redundant_updates=False)` should be `pgbulk.upsert(..., ignore_unchanged=True)`
3. `pgbulk.upsert(..., redundant_updates=True)` should be `pgbulk.upsert(..., ignore_unchanged=False)`

For 1), it's likely you don't need to change invocations if not using `returning`, however, be aware that updates will still be applied even if the rows aren't changed