### PR TITLE
Add `pgbulk.copy` to support `COPY FROM` operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 3.0.0
+
+#### Breaking Changes
+
+  - The `redundant_updates` flag for `pgbulk.upsert` was renamed to `ignore_unchanged`, and the default behavior was flipped by [@wesleykendall](https://github.com/wesleykendall) in [#38](https://github.com/Opus10/django-pgbulk/pull/38).
+
+    Unlike before, unchanged rows are *not* ignored by default. See [the pull request](https://github.com/Opus10/django-pgbulk/pull/38) for a guide on how to update invocations from version 2.
+
+#### Features
+
+  - Support update expressions, `returning`, and `ignore_unchanged` in `pgbulk.update` by [@wesleykendall](https://github.com/wesleykendall) in [#38](https://github.com/Opus10/django-pgbulk/pull/38)
+
+    `pgbulk.update`'s interface has reached feature parity with `pgbulk.upsert`, allowing for returning results, ignoring unchanged rows from being updated, and bulk updates with expressions.
+
+  - New `pgbulk.copy` function that leverages `COPY ... FROM` by [@wesleykendall](https://github.com/wesleykendall) in [#39](https://github.com/Opus10/django-pgbulk/pull/39)
+
+    `pgbulk.copy` wraps Postgres's `COPY ... FROM` to insert data. Can be dramatically faster than Django's `bulk_create`.
+
+#### Changes
+
+  - Django 5.1 compatibilty, dropped Django 3.2 / Postgres 12 support by [@wesleykendall](https://github.com/wesleykendall) in [#37](https://github.com/Opus10/django-pgbulk/pull/37).
+
 ## 2.5.0 (2024-08-09)
 
 #### Feature

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # django-pgbulk
 
-`django-pgbulk` provides functions for doing native Postgres bulk upserts (i.e. [UPDATE ON CONFLICT](https://www.postgresql.org/docs/current/sql-insert.html)) and bulk updates.
+`django-pgbulk` provides functions for doing native Postgres bulk upserts (i.e. [UPDATE ON CONFLICT](https://www.postgresql.org/docs/current/sql-insert.html)), bulk updates, and [COPY FROM](https://www.postgresql.org/docs/current/sql-copy.html).
 
-Bulk upserts can distinguish between updated and created rows and optionally ignore redundant updates.
+Bulk upserts can distinguish between updated/created rows and ignore unchanged updates.
 
 Bulk updates are true bulk updates, unlike Django's [bulk_update](https://docs.djangoproject.com/en/4.2/ref/models/querysets/#bulk-update) which can still suffer from *O(N)* queries and can create poor locking scenarios.
 
+Bulk copies can significantly speed-up bulk inserts, sometimes by an order of magnitude over Django's `bulk_create`.
+
 ## Quick Start
+
+### Examples
 
 Do a bulk upsert on a model:
 
@@ -40,23 +44,40 @@ Do a bulk update on a model:
         ['some_attr']
     )
 
-[View the django-pgbulk docs](https://django-pgbulk.readthedocs.io/) for more information.
+Do a bulk copy on a model:
+
+    import pgbulk
+
+    pgbulk.copy(
+        MyModel,
+        # Insert these rows using COPY FROM
+        [
+            MyModel(id=1, some_attr='some_val1'),
+            MyModel(id=2, some_attr='some_val2')
+        ],
+    )
+
+### Advanced Features
+
+Here are some advanced features at a glance:
+
+- `pgbulk.upsert` can categorize which rows were inserted or updated.
+- `pgbulk.upsert` and `pgbulk.update` can ignore updating unchanged fields.
+- `pgbulk.upsert` and `pgbulk.update` can use expressions in updates.
+
+## Documentation
+
+[View the django-pgbulk docs here](https://django-pgbulk.readthedocs.io/) for more examples.
 
 ## Compatibility
 
 `django-pgbulk` is compatible with Python 3.8 - 3.12, Django 4.2 - 5.1, Psycopg 2 - 3, and Postgres 13 - 16.
-
-## Documentation
-
-[View the django-pgbulk docs here](https://django-pgbulk.readthedocs.io/)
 
 ## Installation
 
 Install `django-pgbulk` with:
 
     pip3 install django-pgbulk
-
-After this, add `pgbulk` to the `INSTALLED_APPS` setting of your Django project.
 
 ## Contributing Guide
 

--- a/README.md
+++ b/README.md
@@ -12,50 +12,56 @@ Bulk copies can significantly speed-up bulk inserts, sometimes by an order of ma
 
 ### Examples
 
-Do a bulk upsert on a model:
+#### Update or insert rows
 
-    import pgbulk
+```python
+import pgbulk
 
-    pgbulk.upsert(
-        MyModel,
-        [
-            MyModel(int_field=1, some_attr="some_val1"),
-            MyModel(int_field=2, some_attr="some_val2"),
-        ],
-        # These are the fields that identify the uniqueness constraint.
-        ["int_field"],
-        # These are the fields that will be updated if the row already
-        # exists. If not provided, all fields will be updated
-        ["some_attr"]
-    )
+pgbulk.upsert(
+    MyModel,
+    [
+        MyModel(int_field=1, some_attr="some_val1"),
+        MyModel(int_field=2, some_attr="some_val2"),
+    ],
+    # These are the fields that identify the uniqueness constraint.
+    ["int_field"],
+    # These are the fields that will be updated if the row already
+    # exists. If not provided, all fields will be updated
+    ["some_attr"]
+)
+```
 
-Do a bulk update on a model:
+#### Bulk update rows
 
-    import pgbulk
+```python
+import pgbulk
 
-    pgbulk.update(
-        MyModel,
-        [
-            MyModel(id=1, some_attr='some_val1'),
-            MyModel(id=2, some_attr='some_val2')
-        ],
-        # These are the fields that will be updated. If not provided,
-        # all fields will be updated
-        ['some_attr']
-    )
+pgbulk.update(
+    MyModel,
+    [
+        MyModel(id=1, some_attr='some_val1'),
+        MyModel(id=2, some_attr='some_val2')
+    ],
+    # These are the fields that will be updated. If not provided,
+    # all fields will be updated
+    ['some_attr']
+)
+```
 
-Do a bulk copy on a model:
+#### Copy rows into a table
 
-    import pgbulk
+```python
+import pgbulk
 
-    pgbulk.copy(
-        MyModel,
-        # Insert these rows using COPY FROM
-        [
-            MyModel(id=1, some_attr='some_val1'),
-            MyModel(id=2, some_attr='some_val2')
-        ],
-    )
+pgbulk.copy(
+    MyModel,
+    # Insert these rows using COPY FROM
+    [
+        MyModel(id=1, some_attr='some_val1'),
+        MyModel(id=2, some_attr='some_val2')
+    ],
+)
+```
 
 ### Advanced Features
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -2,13 +2,18 @@
 
 `django-pgbulk` comes with the following functions:
 
-- Use [pgbulk.upsert][] to do a native Postgres `INSERT ON CONFLICT` statement.
-- Use [pgbulk.update][] to do a native Postgres bulk `UPDATE` statement.
-- Use [pgbulk.aupsert][] or [pgbulk.aupdate][] for async versions of these functions.
+- Use [pgbulk.upsert][] to do an `INSERT ON CONFLICT` statement.
+- Use [pgbulk.update][] to do a bulk `UPDATE` statement.
+- Use [pgbulk.copy][] to do a `COPY FROM` statement.
+- Use [pgbulk.aupsert][], [pgbulk.aupdate][], or [pgbulk.acopy][] for async versions.
 
 Below we show examples and advanced functionality.
 
 ## Using `pgbulk.upsert`
+
+[pgbulk.upsert][] allows for updating or inserting rows atomically and returning results based on inserts or updates. Update fields, returned values, and ignoring unchanged rows can be configured.
+
+See [the Postgres INSERT docs](https://www.postgresql.org/docs/current/sql-insert.html) for more information on how `ON CONFLICT` works.
 
 #### A basic bulk upsert on a model
 
@@ -97,6 +102,8 @@ pgbulk.upsert(
 
 ## Using `pgbulk.update`
 
+[pgbulk.update][] issues updates to multiple rows with an `UPDATE SET ... FROM VALUES` statement. Update fields, returned values, and ignoring unchanged rows can be configured.
+
 #### Update an attribute of multiple models in bulk
 
 ```python
@@ -171,3 +178,53 @@ pgbulk.upsert(
 !!! warning
 
     Triggers and auto-generated fields not in the update won't be applied. Unchanged rows also won't be returned if using `returning=True`.
+
+## Using `pgbulk.copy`
+
+Using `pgbulk.copy` issues a `COPY ... FROM STDIN` statement to insert rows, which can be substantially faster than bulk `INSERT` statement or Django's `bulk_create`. Unlike `bulk_create`, `pgbulk.copy` cannot return inserted results.
+
+!!! note
+
+    `pgbulk.copy` is not only available when using psycopg2.
+
+#### Inserting Rows
+
+```python
+import pgbulk
+
+pgbulk.copy(
+    models.TestModel,
+    [
+        models.TestModel(int_field=5, float_field=1),
+        models.TestModel(int_field=6, float_field=2),
+        models.TestModel(int_field=7, float_field=3),
+    ],
+)
+```
+
+#### Inserting Specific Columns
+
+Specify columns or use `exclude` to configure which columns are copied:
+
+```python
+pgbulk.copy(
+    models.TestModel,
+    [
+        models.TestModel(int_field=5, float_field=1),
+        models.TestModel(int_field=6, float_field=2),
+        models.TestModel(int_field=7, float_field=3),
+    ],
+    ["int_field"]  # Only copy the int_field
+)
+```
+
+```python
+pgbulk.copy(
+    ...,
+    exclude=["generated_field"]  # Exclude only this field
+)
+```
+
+!!! note
+
+    Columns that are excluded from the copy must be generated, nullable, or have database defaults.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -61,7 +61,7 @@ print(results.updated)
 
 #### Use an expression for updates
 
-In the example, we increment `some_int_field` by one whenever an update happens. Otherwise it defaults to zero:
+In this example, we increment `some_int_field` by one whenever an update happens. Otherwise it defaults to zero:
 
 ```python
 pgbulk.upsert(
@@ -81,7 +81,7 @@ pgbulk.upsert(
 )
 ```
 
-#### Ignore updating unchanged rows
+#### Ignore updates to unchanged rows
 
 ```python
 pgbulk.upsert(
@@ -161,7 +161,7 @@ results = pgbulk.upsert(
 print(results[0].int_field)
 ```
 
-#### Ignore updating unchanged rows
+#### Ignore updates to unchanged rows
 
 ```python
 pgbulk.upsert(

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,48 +14,54 @@
 
 Do a bulk upsert on a model:
 
-    import pgbulk
+```python
+import pgbulk
 
-    pgbulk.upsert(
-        MyModel,
-        [
-            MyModel(int_field=1, some_attr="some_val1"),
-            MyModel(int_field=2, some_attr="some_val2"),
-        ],
-        # These are the fields that identify the uniqueness constraint.
-        ["int_field"],
-        # These are the fields that will be updated if the row already
-        # exists. If not provided, all fields will be updated
-        ["some_attr"]
-    )
+pgbulk.upsert(
+    MyModel,
+    [
+        MyModel(int_field=1, some_attr="some_val1"),
+        MyModel(int_field=2, some_attr="some_val2"),
+    ],
+    # These are the fields that identify the uniqueness constraint.
+    ["int_field"],
+    # These are the fields that will be updated if the row already
+    # exists. If not provided, all fields will be updated
+    ["some_attr"]
+)
+```
 
 Do a bulk update on a model:
 
-    import pgbulk
+```python
+import pgbulk
 
-    pgbulk.update(
-        MyModel,
-        [
-            MyModel(id=1, some_attr='some_val1'),
-            MyModel(id=2, some_attr='some_val2')
-        ],
-        # These are the fields that will be updated. If not provided,
-        # all fields will be updated
-        ['some_attr']
-    )
+pgbulk.update(
+    MyModel,
+    [
+        MyModel(id=1, some_attr='some_val1'),
+        MyModel(id=2, some_attr='some_val2')
+    ],
+    # These are the fields that will be updated. If not provided,
+    # all fields will be updated
+    ['some_attr']
+)
+```
 
 Do a bulk copy on a model:
 
-    import pgbulk
+```python
+import pgbulk
 
-    pgbulk.copy(
-        MyModel,
-        # Insert these rows using COPY FROM
-        [
-            MyModel(id=1, some_attr='some_val1'),
-            MyModel(id=2, some_attr='some_val2')
-        ],
-    )
+pgbulk.copy(
+    MyModel,
+    # Insert these rows using COPY FROM
+    [
+        MyModel(id=1, some_attr='some_val1'),
+        MyModel(id=2, some_attr='some_val2')
+    ],
+)
+```
 
 ## Advanced Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,11 +3,12 @@
 `django-pgbulk` provides several optimized bulk operations for Postgres:
 
 1. [pgbulk.update][] - For updating a list of models in bulk. Although Django provides a `bulk_update` in 2.2, it performs individual updates for every row in some circumstances and does not perform a native bulk update.
-2. [pgbulk.upsert][] - For doing a bulk update or insert. This function uses Postgres's `UPDATE ON CONFLICT` syntax to perform an atomic upsert operation. There are several options to this function that allow the user to avoid touching rows if they result in a duplicate update, along with returning which rows were updated or created. Users can also use `models.F` objects on conflicts.
+2. [pgbulk.upsert][] - For doing a bulk update or insert. This function uses Postgres's `UPDATE ON CONFLICT` syntax to perform an atomic upsert operation.
+3. [pgbulk.copy][] - For inserting values using `COPY FROM`. Can be significantly faster than a native `INSERT` or Django's `bulk_create`.
 
 !!! note
 
-    Use [pgbulk.aupdate][] and [pgbulk.aupsert][] for async-compatible versions.
+    Use [pgbulk.aupdate][], [pgbulk.aupsert][], and [pgbulk.acopy][] for async-compatible versions.
 
 ## Quick Start
 
@@ -42,6 +43,27 @@ Do a bulk update on a model:
         # all fields will be updated
         ['some_attr']
     )
+
+Do a bulk copy on a model:
+
+    import pgbulk
+
+    pgbulk.copy(
+        MyModel,
+        # Insert these rows using COPY FROM
+        [
+            MyModel(id=1, some_attr='some_val1'),
+            MyModel(id=2, some_attr='some_val2')
+        ],
+    )
+
+## Advanced Features
+
+Here are some advanced features at a glance:
+
+- [pgbulk.upsert][] can categorize which rows were inserted or updated.
+- [pgbulk.upsert][] and [pgbulk.update][] can ignore updating unchanged fields.
+- [pgbulk.upsert][] and [pgbulk.update][] can use expressions in updates.
 
 ## Compatibility
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,9 @@
 
 ## Quick Start
 
-Do a bulk upsert on a model:
+### Examples
+
+#### Update or insert rows
 
 ```python
 import pgbulk
@@ -31,7 +33,7 @@ pgbulk.upsert(
 )
 ```
 
-Do a bulk update on a model:
+#### Bulk update rows
 
 ```python
 import pgbulk
@@ -48,7 +50,7 @@ pgbulk.update(
 )
 ```
 
-Do a bulk copy on a model:
+#### Copy rows into a table
 
 ```python
 import pgbulk
@@ -63,7 +65,7 @@ pgbulk.copy(
 )
 ```
 
-## Advanced Features
+### Advanced Features
 
 Here are some advanced features at a glance:
 

--- a/pgbulk/__init__.py
+++ b/pgbulk/__init__.py
@@ -1,12 +1,23 @@
 """
 Bulk Postgres upsert and update functions:
 
-- Use [pgbulk.upsert][] to do a native Postgres `INSERT ON CONFLICT` statement.
-- Use [pgbulk.update][] to do a native Postgres bulk `UPDATE` statement.
-- Use [pgbulk.aupsert][] or [pgbulk.aupdate][] for async versions of these functions.
+- Use [pgbulk.upsert][] to do an `INSERT ON CONFLICT` statement.
+- Use [pgbulk.update][] to do a bulk `UPDATE` statement.
+- Use [pgbulk.copy][] to do a `COPY FROM` statement.
+- Use [pgbulk.aupsert][], [pgbulk.aupdate][], or [pgbulk.acopy][] for async versions.
 """
 
-from pgbulk.core import UpdateField, UpsertResult, aupdate, aupsert, update, upsert
+from pgbulk.core import UpdateField, UpsertResult, acopy, aupdate, aupsert, copy, update, upsert
 from pgbulk.version import __version__
 
-__all__ = ["update", "aupdate", "upsert", "aupsert", "UpsertResult", "UpdateField", "__version__"]
+__all__ = [
+    "acopy",
+    "update",
+    "aupdate",
+    "copy",
+    "upsert",
+    "aupsert",
+    "UpsertResult",
+    "UpdateField",
+    "__version__",
+]

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -771,7 +771,7 @@ def copy(
         copy_fields: A list of fields on the model objects to copy.
             If `None`, all fields will be copied.
         exclude: A list of fields to exclude from the copy. This is useful
-            when `update_fields` is `None` and you want to exclude fields from
+            when `copy_fields` is `None` and you want to exclude fields from
             being copied.
 
     Note:

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -777,7 +777,7 @@ def copy(
     Note:
         Model signals such as `post_save` are not emitted.
     """
-    if psycopg_maj_version == 2:
+    if psycopg_maj_version == 2:  # pragma: no cover
         raise RuntimeError("Only psycopg3 is supported for pgbulk.copy.")
 
     queryset = queryset if isinstance(queryset, models.QuerySet) else queryset.objects.all()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "2.5.0"
-description = "Native postgres bulk update and upsert operations."
+version = "3.0.0"
+description = "Native Postgres update, upsert, and copy operations."
 authors = ["Wes Kendall"]
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
`pgbulk` now supports `pgbulk.copy`, wrapping native `COPY ... FROM STDIN` in Postgres. `psycopg2` is not supported.

In basic local runs, `pgbulk.copy` is 5x faster than Django's `bulk_create` when inserting 100K rows. Others have seen similar speed-ups for using `COPY` for inserts over regular `INSERT`.