### PR TITLE
Add overloads on `returning`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.1
+
+#### Trivial
+
+  - Add overloads on `upsert`, `aupsert`, `update`, and `aupdate` to improve type-checking on `returning=...` by [@max-muoto](https://github.com/max-muoto) in [#40](https://github.com/Opus10/django-pgbulk/pull/40/).
+
 ## 3.0.0
 
 #### Breaking Changes

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -1,16 +1,17 @@
 import itertools
+import typing
 from typing import (
     TYPE_CHECKING,
     Any,
     Iterable,
     List,
-    Literal,
     NamedTuple,
     Tuple,
     Type,
     TypeVar,
     Union,
     cast,
+    overload,
 )
 
 from asgiref.sync import sync_to_async
@@ -37,7 +38,7 @@ if TYPE_CHECKING:
     class Row(NamedTuple):
         """Represents a row returned by an upsert operation."""
 
-        status_: Literal["u", "c"]
+        status_: typing.Literal["u", "c"]
 
         def __getattr__(self, item: str) -> Any: ...
 
@@ -598,6 +599,42 @@ def _update(
     return updated if returning else None
 
 
+@overload
+def update(
+    queryset: QuerySet[_M],
+    model_objs: Iterable[_M],
+    update_fields: Union[List[str], None] = None,
+    *,
+    exclude: Union[List[str], None] = None,
+    returning: Union[List[str], typing.Literal[True]] = ...,
+    ignore_unchanged: bool = False,
+) -> List["Row"]: ...
+
+
+@overload
+def update(
+    queryset: QuerySet[_M],
+    model_objs: Iterable[_M],
+    update_fields: Union[List[str], None] = None,
+    *,
+    exclude: Union[List[str], None] = None,
+    returning: typing.Literal[False] = False,
+    ignore_unchanged: bool = False,
+) -> None: ...
+
+
+@overload
+def update(
+    queryset: QuerySet[_M],
+    model_objs: Iterable[_M],
+    update_fields: Union[List[str], None] = None,
+    *,
+    exclude: Union[List[str], None] = None,
+    returning: Union[List[str], bool] = False,
+    ignore_unchanged: bool = False,
+) -> Union[List["Row"], None]: ...
+
+
 def update(
     queryset: QuerySet[_M],
     model_objs: Iterable[_M],
@@ -641,6 +678,42 @@ def update(
         )
 
 
+@overload
+async def aupdate(
+    queryset: QuerySet[_M],
+    model_objs: Iterable[_M],
+    update_fields: Union[List[str], None] = None,
+    *,
+    exclude: Union[List[str], None] = None,
+    returning: Union[List[str], typing.Literal[True]] = ...,
+    ignore_unchanged: bool = False,
+) -> List["Row"]: ...
+
+
+@overload
+async def aupdate(
+    queryset: QuerySet[_M],
+    model_objs: Iterable[_M],
+    update_fields: Union[List[str], None] = None,
+    *,
+    exclude: Union[List[str], None] = None,
+    returning: typing.Literal[False] = False,
+    ignore_unchanged: bool = False,
+) -> None: ...
+
+
+@overload
+async def aupdate(
+    queryset: QuerySet[_M],
+    model_objs: Iterable[_M],
+    update_fields: Union[List[str], None] = None,
+    *,
+    exclude: Union[List[str], None] = None,
+    returning: Union[List[str], bool] = False,
+    ignore_unchanged: bool = False,
+) -> Union[List["Row"], None]: ...
+
+
 async def aupdate(
     queryset: QuerySet[_M],
     model_objs: Iterable[_M],
@@ -668,6 +741,45 @@ async def aupdate(
         returning=returning,
         ignore_unchanged=ignore_unchanged,
     )
+
+
+@overload
+def upsert(
+    queryset: QuerySet[_M],
+    model_objs: Iterable[_M],
+    unique_fields: List[str],
+    update_fields: UpdateFieldsTypeDef = None,
+    *,
+    exclude: Union[List[str], None] = None,
+    returning: Union[List[str], typing.Literal[True]] = ...,
+    ignore_unchanged: bool = False,
+) -> UpsertResult: ...
+
+
+@overload
+def upsert(
+    queryset: QuerySet[_M],
+    model_objs: Iterable[_M],
+    unique_fields: List[str],
+    update_fields: UpdateFieldsTypeDef = None,
+    *,
+    exclude: Union[List[str], None] = None,
+    returning: typing.Literal[False] = False,
+    ignore_unchanged: bool = False,
+) -> None: ...
+
+
+@overload
+def upsert(
+    queryset: QuerySet[_M],
+    model_objs: Iterable[_M],
+    unique_fields: List[str],
+    update_fields: UpdateFieldsTypeDef = None,
+    *,
+    exclude: Union[List[str], None] = None,
+    returning: Union[List[str], bool] = False,
+    ignore_unchanged: bool = False,
+) -> Union[UpsertResult, None]: ...
 
 
 def upsert(
@@ -722,6 +834,45 @@ def upsert(
             ignore_unchanged=ignore_unchanged,
             cursor=cursor,
         )
+
+
+@overload
+async def aupsert(
+    queryset: QuerySet[_M],
+    model_objs: Iterable[_M],
+    unique_fields: List[str],
+    update_fields: UpdateFieldsTypeDef = None,
+    *,
+    exclude: Union[List[str], None] = None,
+    returning: Union[List[str], typing.Literal[True]] = ...,
+    ignore_unchanged: bool = False,
+) -> UpsertResult: ...
+
+
+@overload
+async def aupsert(
+    queryset: QuerySet[_M],
+    model_objs: Iterable[_M],
+    unique_fields: List[str],
+    update_fields: UpdateFieldsTypeDef = None,
+    *,
+    exclude: Union[List[str], None] = None,
+    returning: typing.Literal[False] = False,
+    ignore_unchanged: bool = False,
+) -> None: ...
+
+
+@overload
+async def aupsert(
+    queryset: QuerySet[_M],
+    model_objs: Iterable[_M],
+    unique_fields: List[str],
+    update_fields: UpdateFieldsTypeDef = None,
+    *,
+    exclude: Union[List[str], None] = None,
+    returning: Union[List[str], bool] = False,
+    ignore_unchanged: bool = False,
+) -> Union[UpsertResult, None]: ...
 
 
 async def aupsert(

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -1,10 +1,10 @@
 import itertools
-import typing
 from typing import (
     TYPE_CHECKING,
     Any,
     Iterable,
     List,
+    Literal,
     NamedTuple,
     Tuple,
     Type,
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     class Row(NamedTuple):
         """Represents a row returned by an upsert operation."""
 
-        status_: typing.Literal["u", "c"]
+        status_: Literal["u", "c"]
 
         def __getattr__(self, item: str) -> Any: ...
 
@@ -64,7 +64,6 @@ psycopg_maj_version = psycopg_version[0]
 
 
 if psycopg_maj_version == 2:
-    from psycopg2.extensions import AsIs as Literal  # type: ignore
     from psycopg2.extensions import quote_ident  # type: ignore
 elif psycopg_maj_version == 3:
     import psycopg.adapt  # type: ignore
@@ -606,7 +605,7 @@ def update(
     update_fields: Union[List[str], None] = None,
     *,
     exclude: Union[List[str], None] = None,
-    returning: Union[List[str], typing.Literal[True]] = ...,
+    returning: Union[List[str], Literal[True]] = ...,
     ignore_unchanged: bool = False,
 ) -> List["Row"]: ...
 
@@ -618,7 +617,7 @@ def update(
     update_fields: Union[List[str], None] = None,
     *,
     exclude: Union[List[str], None] = None,
-    returning: typing.Literal[False] = False,
+    returning: Literal[False] = False,
     ignore_unchanged: bool = False,
 ) -> None: ...
 
@@ -685,7 +684,7 @@ async def aupdate(
     update_fields: Union[List[str], None] = None,
     *,
     exclude: Union[List[str], None] = None,
-    returning: Union[List[str], typing.Literal[True]] = ...,
+    returning: Union[List[str], Literal[True]] = ...,
     ignore_unchanged: bool = False,
 ) -> List["Row"]: ...
 
@@ -697,7 +696,7 @@ async def aupdate(
     update_fields: Union[List[str], None] = None,
     *,
     exclude: Union[List[str], None] = None,
-    returning: typing.Literal[False] = False,
+    returning: Literal[False] = False,
     ignore_unchanged: bool = False,
 ) -> None: ...
 
@@ -751,7 +750,7 @@ def upsert(
     update_fields: UpdateFieldsTypeDef = None,
     *,
     exclude: Union[List[str], None] = None,
-    returning: Union[List[str], typing.Literal[True]] = ...,
+    returning: Union[List[str], Literal[True]] = ...,
     ignore_unchanged: bool = False,
 ) -> UpsertResult: ...
 
@@ -764,7 +763,7 @@ def upsert(
     update_fields: UpdateFieldsTypeDef = None,
     *,
     exclude: Union[List[str], None] = None,
-    returning: typing.Literal[False] = False,
+    returning: Literal[False] = False,
     ignore_unchanged: bool = False,
 ) -> None: ...
 
@@ -844,7 +843,7 @@ async def aupsert(
     update_fields: UpdateFieldsTypeDef = None,
     *,
     exclude: Union[List[str], None] = None,
-    returning: Union[List[str], typing.Literal[True]] = ...,
+    returning: Union[List[str], Literal[True]] = ...,
     ignore_unchanged: bool = False,
 ) -> UpsertResult: ...
 
@@ -857,7 +856,7 @@ async def aupsert(
     update_fields: UpdateFieldsTypeDef = None,
     *,
     exclude: Union[List[str], None] = None,
-    returning: typing.Literal[False] = False,
+    returning: Literal[False] = False,
     ignore_unchanged: bool = False,
 ) -> None: ...
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "3.0.0"
+version = "3.0.1"
 description = "Native Postgres update, upsert, and copy operations."
 authors = ["Wes Kendall"]
 classifiers = [


### PR DESCRIPTION
This PR adds overloads on `returning` to help provide more accurate type-checking. If `returning` is `True` or a list `UpsertResult` is the return-type, otherwise `None`.