### PR TITLE
Fix Minor Overload Resolution Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Trivial
 
-  - Remove elipses defaults on overloads to avoide incorrect resolution by by [@max-muoto](https://github.com/max-muoto) in [#40](https://github.com/Opus10/django-pgbulk/pull/41/).
+  - Remove elipses defaults on overloads to avoide incorrect resolution by by [@max-muoto](https://github.com/max-muoto) in [#41](https://github.com/Opus10/django-pgbulk/pull/41/).
 
 ## 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.2
+
+#### Trivial
+
+  - Remove elipses defaults on overloads to avoide incorrect resolution by by [@max-muoto](https://github.com/max-muoto) in [#40](https://github.com/Opus10/django-pgbulk/pull/41/).
+
 ## 3.0.1
 
 #### Trivial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Trivial
 
-  - Remove elipses defaults on overloads to avoide incorrect resolution by by [@max-muoto](https://github.com/max-muoto) in [#41](https://github.com/Opus10/django-pgbulk/pull/41/).
+  - Remove elipses defaults on overloads to avoid incorrect resolution by [@max-muoto](https://github.com/max-muoto) in [#41](https://github.com/Opus10/django-pgbulk/pull/41/).
 
 ## 3.0.1
 

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -605,7 +605,7 @@ def update(
     update_fields: Union[List[str], None] = None,
     *,
     exclude: Union[List[str], None] = None,
-    returning: Union[List[str], Literal[True]] = ...,
+    returning: Union[List[str], Literal[True]],
     ignore_unchanged: bool = False,
 ) -> List["Row"]: ...
 
@@ -684,7 +684,7 @@ async def aupdate(
     update_fields: Union[List[str], None] = None,
     *,
     exclude: Union[List[str], None] = None,
-    returning: Union[List[str], Literal[True]] = ...,
+    returning: Union[List[str], Literal[True]],
     ignore_unchanged: bool = False,
 ) -> List["Row"]: ...
 
@@ -750,7 +750,7 @@ def upsert(
     update_fields: UpdateFieldsTypeDef = None,
     *,
     exclude: Union[List[str], None] = None,
-    returning: Union[List[str], Literal[True]] = ...,
+    returning: Union[List[str], Literal[True]],
     ignore_unchanged: bool = False,
 ) -> UpsertResult: ...
 
@@ -843,7 +843,7 @@ async def aupsert(
     update_fields: UpdateFieldsTypeDef = None,
     *,
     exclude: Union[List[str], None] = None,
-    returning: Union[List[str], Literal[True]] = ...,
+    returning: Union[List[str], Literal[True]],
     ignore_unchanged: bool = False,
 ) -> UpsertResult: ...
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "3.0.1"
+version = "3.0.2"
 description = "Native Postgres update, upsert, and copy operations."
 authors = ["Wes Kendall"]
 classifiers = [


### PR DESCRIPTION
Fix minor typing issue where (at least in Pyright) assigning elipses can cause overloads to incorrectly get picked up (`False` is set as the default, but the elipses overload is chosen).