### PR TITLE
Support Django 5.0 DB defaults within `pgbulk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Feature
 
   - Add support for db defaults in `pgbulk.upsert` by [@max-muoto](https://github.com/max-muoto) in [#42](https://github.com/Opus10/django-pgbulk/pull/42).
+  - Support binary mode for `pgbulk.copy` by [@max-muoto](https://github.com/max-muoto) in [#45](https://github.com/Opus10/django-pgbulk/pull/45)
 
 ## 3.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.0
+
+#### Feature
+
+  - Add support for db defaults in `pgbulk.upsert` by [@max-muoto](https://github.com/max-muoto) in [#42](https://github.com/Opus10/django-pgbulk/pull/42).
+
 ## 3.0.2
 
 #### Trivial

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -321,10 +321,10 @@ def _format_placeholders_row(
     include_cast: bool,
 ) -> str:
     placeholders = ", ".join(
-        f"{'%s'}{f'::{f.db_type(connection)}' if include_cast else ''}"
+        f"{'%s'}{f'::{field.db_type(connection)}' if include_cast else ''}"
         if val is not _DB_DEFAULT
         else "DEFAULT"
-        for val, f in zip(values_for_row, all_fields)
+        for val, field in zip(values_for_row, all_fields)
     )
     return f"({placeholders})"
 

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -256,7 +256,10 @@ def _get_field_db_val(
             return _DB_DEFAULT
         else:
             raise ValueError(
-                "DB defaults are not supported when copying, please provide an ORM default value"
+                (
+                    "DB defaults are not supported when copying, "
+                    "please provide an ORM default with `default=`"
+                )
             )
 
     elif hasattr(value, "resolve_expression"):  # pragma: no cover

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -15,8 +15,10 @@ from typing import (
 )
 
 from asgiref.sync import sync_to_async
+from django import __version__ as DJANGO_VERSION
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connections, models
+from django.db.models import expressions
 from django.db.models.sql.compiler import SQLCompiler
 from django.utils import timezone
 from django.utils.version import get_version_tuple
@@ -29,6 +31,9 @@ _M = TypeVar("_M", bound=models.Model)
 QuerySet: TypeAlias = Union[Type[_M], models.QuerySet[_M]]
 AnyField: TypeAlias = "models.Field[Any, Any]"
 Expression: TypeAlias = "models.Expression | models.F"
+
+
+class _DB_DEFAULT: ...
 
 
 if TYPE_CHECKING:
@@ -59,6 +64,7 @@ def _psycopg_version() -> Tuple[int, int, int]:
     return version_tuple
 
 
+django_version = DJANGO_VERSION
 psycopg_version = _psycopg_version()
 psycopg_maj_version = psycopg_version[0]
 
@@ -232,13 +238,28 @@ def _prep_sql_args(
     ]
 
 
+def _value_is_db_default(value: Any) -> bool:
+    """Check if the value is a database default, they were introduced in Django 5.0"""
+    return django_version >= "5.0" and isinstance(value, expressions.DatabaseDefault)  # type: ignore - missing stubs
+
+
 def _get_field_db_val(
     queryset: models.QuerySet[_M],
     field: AnyField,
     value: Any,
     connection: "DefaultConnectionProxy",
-) -> Any:
-    if hasattr(value, "resolve_expression"):  # pragma: no cover
+    *,
+    copying: bool = False,
+) -> "Any | _DB_DEFAULT":
+    if _value_is_db_default(value):
+        if not copying:
+            return _DB_DEFAULT
+        else:
+            raise ValueError(
+                "DB defaults are not supported when copying, please provide an ORM default value"
+            )
+
+    elif hasattr(value, "resolve_expression"):  # pragma: no cover
         # Handle cases when the field is of type "Func" and other expressions.
         # This is useful for libraries like django-rdkit that can't easily be tested
         return value.resolve_expression(queryset.query, allow_joins=False, for_save=True)
@@ -274,14 +295,34 @@ def _get_values_for_row(
     queryset: models.QuerySet[_M],
     model_obj: _M,
     all_fields: List[AnyField],
+    *,
+    copying: bool = False,
 ) -> List[Any]:
     connection = connections[queryset.db]
     return [
         # Convert field value to db value
         # Use attname here to support fields with custom db_column names
-        _get_field_db_val(queryset, field, getattr(model_obj, field.attname), connection)
+        _get_field_db_val(
+            queryset, field, getattr(model_obj, field.attname), connection, copying=copying
+        )
         for field in all_fields
     ]
+
+
+def _format_placeholders_row(
+    values_for_row: List[Any],
+    all_fields: List[AnyField],
+    connection: "DefaultConnectionProxy",
+    *,
+    include_cast: bool,
+) -> str:
+    placeholders = ", ".join(
+        f"{'%s'}{f'::{f.db_type(connection)}' if include_cast else ''}"
+        if val is not _DB_DEFAULT
+        else "DEFAULT"
+        for val, f in zip(values_for_row, all_fields)
+    )
+    return f"({placeholders})"
 
 
 def _get_values_for_rows(
@@ -294,15 +335,18 @@ def _get_values_for_rows(
     sql_args: List[Any] = []
 
     for i, model_obj in enumerate(model_objs):
-        sql_args.extend(_get_values_for_row(queryset, model_obj, all_fields))
+        values_for_row = _get_values_for_row(queryset, model_obj, all_fields)
+        sql_args.extend((val for val in values_for_row if val is not _DB_DEFAULT))
         if i == 0:
             row_values.append(
-                "({0})".format(
-                    ", ".join(["%s::{0}".format(f.db_type(connection)) for f in all_fields])
-                )
+                _format_placeholders_row(values_for_row, all_fields, connection, include_cast=True)
             )
         else:
-            row_values.append("({0})".format(", ".join(["%s"] * len(all_fields))))
+            row_values.append(
+                _format_placeholders_row(
+                    values_for_row, all_fields, connection, include_cast=False
+                )
+            )
 
     return row_values, sql_args
 
@@ -407,7 +451,6 @@ def _get_upsert_sql(
     update_db_cols = [model._meta.get_field(update_field).column for update_field in update_fields]
 
     row_values, sql_args = _get_values_for_rows(queryset, model_objs, all_fields)
-
     unique_field_names_sql = ", ".join([_quote(col, cursor) for col in unique_db_cols])
     update_fields_sql, ignore_unchanged_sql = _get_update_fields_sql(
         queryset=queryset,
@@ -952,7 +995,7 @@ def copy(
         )
         with cursor.copy(copy_sql) as copier:  # type: ignore
             for model_obj in model_objs:
-                row = _get_values_for_row(queryset, model_obj, fields)
+                row = _get_values_for_row(queryset, model_obj, fields, copying=True)
                 copier.write_row(row)  # type: ignore
 
 

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -33,7 +33,8 @@ AnyField: TypeAlias = "models.Field[Any, Any]"
 Expression: TypeAlias = "models.Expression | models.F"
 
 
-class _DB_DEFAULT: ...
+class _DB_DEFAULT:
+    """Sentinel value for a database default."""
 
 
 if TYPE_CHECKING:

--- a/pgbulk/tests/models.py
+++ b/pgbulk/tests/models.py
@@ -1,3 +1,4 @@
+from django import __version__ as DJANGO_VERSION
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django_hashids import HashidsField
@@ -90,3 +91,19 @@ class TestPkChar(models.Model):
 
     my_key = models.CharField(max_length=128, primary_key=True)
     char_field = models.CharField(max_length=128, null=True)
+
+
+if DJANGO_VERSION >= "5.0":
+    from django.db.models.functions import Now
+
+    class TestDbDefaultModel(models.Model):
+        """A model to test that database defaults are not upserted"""
+
+        int_field = models.IntegerField(db_default=1)
+        char_field = models.CharField(max_length=128, db_default="test")
+        created_at = models.DateTimeField(db_default=Now())
+
+    class TestDbDefaultModelWithOrmDefault(models.Model):
+        """A model to test that a db default can be paired with an ORM default."""
+
+        int_field = models.IntegerField(db_default=1, default=1)

--- a/pgbulk/tests/test_core.py
+++ b/pgbulk/tests/test_core.py
@@ -1314,7 +1314,7 @@ def test_acopy():
 @pytest.mark.django_db
 def test_upsert_with_db_defaults():
     """
-    Tests upsert behavior with db_defaults.
+    Test that we can properly upsert objects that have db defaults.
     """
     result = pgbulk.upsert(
         models.TestDbDefaultModel,
@@ -1418,7 +1418,7 @@ def test_update_with_db_defaults():
 @pytest.mark.django_db
 def test_copy_with_db_defaults():
     """
-    Testing that copy isn't not supported with db defaults.
+    Test that we cannot copy objects that have db defaults.
     """
     with pytest.raises(
         ValueError, match="DB defaults are not supported when copying"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "3.0.2"
+version = "3.1.0"
 description = "Native Postgres update, upsert, and copy operations."
 authors = ["Wes Kendall"]
 classifiers = [


### PR DESCRIPTION
This PR adds proper support for DB defaults for `pgbulk.upsert`, and proper warnings when using them with `pgbulk.copy`. Additionally it includes basic tests with `pgbulk.update` to at least ensure compatibility. 

Fixes: https://github.com/Opus10/django-pgbulk/issues/43